### PR TITLE
解决了导表中出现的索引无法创建的BUG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ go.work.sum
 mysql2pg
 config.yml
 *.log
+*.exe
 # gitlab ci
 .cache
 .golangci.yml

--- a/internal/converter/postgres/manager.go
+++ b/internal/converter/postgres/manager.go
@@ -188,6 +188,7 @@ func (m *Manager) Run() error {
 					m.Log("警告: 表列表中指定的表 %s 不存在于MySQL数据库中", tableName)
 				}
 			}
+
 			m.totalTasks = len(filteredIndexes)
 			var wg sync.WaitGroup
 			semaphore := make(chan struct{}, m.config.Conversion.Limits.Concurrency)
@@ -278,7 +279,12 @@ func (m *Manager) getMetadata() ([]mysql.TableInfo, []mysql.FunctionInfo, []mysq
 	var err error
 
 	if m.config.Conversion.Options.TableDDL || m.config.Conversion.Options.Indexes || m.config.Conversion.Options.Data || m.config.Conversion.Options.Grant {
-		tables, err = m.mysqlConn.GetTables(m.config.Conversion.Options.SkipUseTableList, m.config.Conversion.Options.SkipTableList)
+		tables, err = m.mysqlConn.GetTables(
+			m.config.Conversion.Options.SkipUseTableList,
+			m.config.Conversion.Options.SkipTableList,
+			m.config.Conversion.Options.UseTableList,
+			m.config.Conversion.Options.TableList,
+		)
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, fmt.Errorf("获取表信息失败: %w", err)
 		}


### PR DESCRIPTION
这里解决了其它的一些BUG，1、当表只有一个主键索引时，数据会导入不完整，只导入部份数据，是数据分页的BUG。
2、PostgreSQL 和 MySQL 在索引命名规则上的差异 ：

- MySQL 允许不同表拥有相同名称的索引（Table-level scope）。
- PostgreSQL 要求同一 Schema 下的所有索引名称必须唯一（Schema-level scope）。
因此，当程序试图创建名为 idx_hotelid 的索引时，PostgreSQL 发现数据库中可能已经存在一个同名索引（属于其他表），于是 IF NOT EXISTS 判断生效，导致创建被跳过。
