### PR TITLE
mysql NewConnection default params remove and sync remove mysql root and mysql.infoschema user info

### DIFF
--- a/internal/mysql/connection.go
+++ b/internal/mysql/connection.go
@@ -19,7 +19,7 @@ type Connection struct {
 // NewConnection 创建新的MySQL连接
 func NewConnection(config *config.MySQLConfig) (*Connection, error) {
 	// 使用无压缩连接
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true&charset=utf8mb4",
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?",
 		config.Username, config.Password, config.Host, config.Port, config.Database)
 
 	// 添加连接参数

--- a/internal/mysql/metadata.go
+++ b/internal/mysql/metadata.go
@@ -536,7 +536,7 @@ func (c *Connection) GetUsers() ([]UserInfo, error) {
 	rows, err := c.db.Query(`
 		SELECT user, host 
 		FROM mysql.user 
-		WHERE user != 'root' AND user != 'mysql.sys' AND user != 'mysql.session'
+		WHERE user != 'root' AND user != 'mysql.sys' AND user != 'mysql.session' AND user != 'mysql.infoschema'
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("获取用户列表失败: %w", err)


### PR DESCRIPTION
1、[mysql NewConnection default params remove](https://github.com/xfg0218/MySQL2PG/commit/2bed3f90f0e5f7ec83bc2dccbf437b265d75634c)
2、[sync remove mysql root and mysql.infoschema user info](https://github.com/xfg0218/MySQL2PG/commit/729a3e0ca62ef1ed9628d4563bc73de2d4934188)