### PR TITLE
feat: add --version/-v flag with CI/CD version injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,13 @@ jobs:
         run: |
           OUTPUT="dist/${{ matrix.goos }}_${{ matrix.goarch }}/mysql2pg${{ matrix.suffix }}"
           echo "Building to $OUTPUT"
+          # Extract version from tag name (e.g., v2.8.0)
+          VERSION="${{ github.event.inputs.tag || github.event.release.tag_name || github.ref_name }}"
           # Adjust the build target below if your main is not in ./cmd
           if [ -f ./cmd/main.go ]; then
-            go build -o "$OUTPUT" -v ./cmd
+            go build -ldflags "-X main.Version=$VERSION" -o "$OUTPUT" -v ./cmd
           else
-            go build -o "$OUTPUT" -v .
+            go build -ldflags "-X main.Version=$VERSION" -o "$OUTPUT" -v .
           fi
 
       - name: Verify binary exists

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,13 @@ CONFIG_FILE=config.yml
 ERROR_FILE=errors.log
 CONVERSION_FILE=conversion.log
 
+# 版本号：优先使用 git tag，否则使用 dev
+VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+
 # 构建项目
 build:
-	@echo "正在构建项目..."
-	@go build -o $(BINARY_NAME) $(SRC_DIR)/
+	@echo "正在构建项目 (版本: $(VERSION))..."
+	@go build -ldflags "-X main.Version=$(VERSION)" -o $(BINARY_NAME) $(SRC_DIR)/
 	@echo "构建完成！可执行文件: $(BINARY_NAME)"
 
 # 运行项目

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,9 @@ import (
 	pgconn "github.com/yourusername/mysql2pg/internal/postgres"
 )
 
+// Version 是工具版本号，构建时通过 ldflags 注入
+var Version = "dev"
+
 func main() {
 
 	// 监听本地 6060 端口，用于性能分析
@@ -31,6 +34,9 @@ func main() {
 	for i := 1; i < len(os.Args); i++ {
 		if os.Args[i] == "-h" || os.Args[i] == "--help" {
 			showHelp()
+			return
+		} else if os.Args[i] == "-v" || os.Args[i] == "--version" {
+			showVersion()
 			return
 		} else if os.Args[i] == "-c" && i+1 < len(os.Args) {
 			configPath = os.Args[i+1]
@@ -170,6 +176,7 @@ func showHelp() {
 	fmt.Println("  mysql2pg [配置文件路径]")
 	fmt.Println("  mysql2pg -c [配置文件路径]")
 	fmt.Println("  mysql2pg report -l <conversion.log>  从日志生成HTML报告")
+	fmt.Println("  mysql2pg -v|--version 显示版本信息")
 	fmt.Println("  mysql2pg -h|--help 显示帮助信息")
 	fmt.Println()
 	fmt.Println("配置文件说明:")
@@ -242,4 +249,9 @@ func showHelp() {
 	fmt.Println("  5. 零数据处理: 支持零数据行表的完整同步流程，包括进度显示和验证")
 	fmt.Println("  6. 完整的资源清理: 所有数据库连接和资源都会被正确释放，避免资源泄漏")
 	fmt.Println("  7. 完善的性能分析: 监听本地 6060 端口，用于性能分析")
+}
+
+// showVersion 显示版本信息
+func showVersion() {
+	fmt.Printf("mysql2pg version %s\n", Version)
 }


### PR DESCRIPTION
- Add Version variable in cmd/main.go (default: dev)
- Support -v/--version CLI flag to display version info
- Update Makefile to inject version via -ldflags from git tag
- Update release.yml to inject GitHub tag version into binaries
- Ensure released binaries match GitHub Releases tag version