### PR TITLE
fix: resolve missing PRIMARY KEY when DDL contains USING BTREE/HASH

### DIFF
--- a/internal/converter/postgres/sync_tableddl.go
+++ b/internal/converter/postgres/sync_tableddl.go
@@ -1003,17 +1003,7 @@ func ConvertTableDDL(mysqlDDL string, lowercaseColumns bool) (*ConvertTableDDLRe
 			}
 		}
 
-		if skipIndexLine ||
-			strings.Contains(upperTrimmedLine, "FOREIGN KEY") ||
-			strings.Contains(upperTrimmedLine, "USING BTREE") ||
-			strings.Contains(upperTrimmedLine, "USING HASH") ||
-			(strings.Contains(trimmedLine, "engine=") && !strings.Contains(trimmedLine, "`") && !strings.Contains(trimmedLine, " ")) ||
-			(strings.Contains(trimmedLine, "ENGINE=") && !strings.Contains(trimmedLine, "`") && !strings.Contains(trimmedLine, " ")) ||
-			(strings.Contains(trimmedLine, "row_format=") && !strings.Contains(trimmedLine, "`") && !strings.Contains(trimmedLine, " ")) ||
-			(strings.Contains(trimmedLine, "ROW_FORMAT=") && !strings.Contains(trimmedLine, "`") && !strings.Contains(trimmedLine, " ")) {
-			continue
-		}
-
+		// 先处理 PRIMARY KEY（即使包含 USING BTREE/HASH 也要提取主键列名）
 		if strings.HasPrefix(strings.ToUpper(trimmedLine), "PRIMARY KEY") {
 			pkColumn := extractPrimaryKeyColumn(trimmedLine)
 			if pkColumn == "" {
@@ -1024,6 +1014,17 @@ func ConvertTableDDL(mysqlDDL string, lowercaseColumns bool) (*ConvertTableDDLRe
 			} else {
 				primaryKeyColumn = pkColumn
 			}
+			continue
+		}
+
+		if skipIndexLine ||
+			strings.Contains(upperTrimmedLine, "FOREIGN KEY") ||
+			strings.Contains(upperTrimmedLine, "USING BTREE") ||
+			strings.Contains(upperTrimmedLine, "USING HASH") ||
+			(strings.Contains(trimmedLine, "engine=") && !strings.Contains(trimmedLine, "`") && !strings.Contains(trimmedLine, " ")) ||
+			(strings.Contains(trimmedLine, "ENGINE=") && !strings.Contains(trimmedLine, "`") && !strings.Contains(trimmedLine, " ")) ||
+			(strings.Contains(trimmedLine, "row_format=") && !strings.Contains(trimmedLine, "`") && !strings.Contains(trimmedLine, " ")) ||
+			(strings.Contains(trimmedLine, "ROW_FORMAT=") && !strings.Contains(trimmedLine, "`") && !strings.Contains(trimmedLine, " ")) {
 			continue
 		}
 


### PR DESCRIPTION
## 问题

当 MySQL 表 DDL 包含 `USING BTREE` 子句的主键定义时（如 `PRIMARY KEY (`id`) USING BTREE`），在迁移到 PostgreSQL 时主键会丢失。

**受影响表示例**：`para_normalize`

## 根因

`sync_tableddl.go` 中 `USING BTREE` 的检查在 `PRIMARY KEY` 提取**之前**执行，导致带有 `USING BTREE` 的主键定义被误跳过，主键列名没有被提取。

## 修复

将 `PRIMARY KEY` 提取逻辑移到 `USING BTREE/USING HASH` 跳过检查之前。

### 修改文件
- `internal/converter/postgres/sync_tableddl.go`

### 代码变更
```diff
- // USING BTREE 检查（第 1006-1014 行）
- if ... USING BTREE ... { continue }
- 
- // PRIMARY KEY 提取（第 1017-1026 行）
- if strings.HasPrefix(..., "PRIMARY KEY") { ... }
+ // PRIMARY KEY 提取（提前执行）
+ if strings.HasPrefix(..., "PRIMARY KEY") { ... }
+ 
+ // USING BTREE 检查（随后执行）
+ if ... USING BTREE ... { continue }
```

## 修复后效果

```sql
-- MySQL 原始定义
PRIMARY KEY (`normalize_id`) USING BTREE

-- ↓ 正确转换为 ↓

-- PostgreSQL DDL 末尾  
PRIMARY KEY ("normalize_id")
```

## 测试

- [x] 编译通过：`go build -o mysql2pg ./cmd/`