### PR TITLE
fix: 修复函数转换中 NUMERIC 类型声明和 CLOSE 语句处理错误

### DIFF
--- a/internal/converter/postgres/function_decl_test.go
+++ b/internal/converter/postgres/function_decl_test.go
@@ -1,0 +1,203 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/yourusername/mysql2pg/internal/mysql"
+)
+
+// TestFunctionVariableDeclarationOrder 测试变量声明顺序问题
+// 复现错误：func_110_case_daily_numeric_risk_tag 的 DECLARE 语句被错误处理
+func TestFunctionVariableDeclarationOrder(t *testing.T) {
+	mysqlDDL := `CREATE FUNCTION func_110_case_daily_numeric_risk_tag(_id BIGINT UNSIGNED)
+RETURNS VARCHAR(16)
+READS SQL DATA
+BEGIN
+    DECLARE v_dec_high DECIMAL(65,30) DEFAULT 0;
+    DECLARE v_ratio NUMERIC(20,10) DEFAULT 0;
+    SELECT IFNULL(dec_high, 0), IFNULL(ratio, 0)
+      INTO v_dec_high, v_ratio
+    FROM case_160_numeric_boundary
+    WHERE id = _id
+    LIMIT 1;
+    IF v_dec_high >= 1000000000000 OR v_ratio >= 100000 THEN
+        RETURN 'HIGH';
+    ELSEIF v_dec_high >= 1000000 OR v_ratio >= 1000 THEN
+        RETURN 'MEDIUM';
+    END IF;
+    RETURN 'LOW';
+END`
+
+	result, err := ConvertFunctionDDL(mysql.FunctionInfo{
+		Name: "func_110_case_daily_numeric_risk_tag",
+		DDL:  mysqlDDL,
+	})
+
+	if err != nil {
+		t.Fatalf("转换失败：%v", err)
+	}
+
+	t.Logf("转换结果:\n%s", result)
+
+	// 检查 DECLARE 块是否正确
+	if !strings.Contains(result, "DECLARE") {
+		t.Error("缺少 DECLARE 块")
+	}
+
+	// 检查变量声明是否在 DECLARE 块中（而不是在 BEGIN 之后）
+	if strings.Contains(result, "BEGIN\nv_ratio") || strings.Contains(result, "BEGIN\nv_dec_high") {
+		t.Error("变量声明错误地出现在 BEGIN 之后，应该在 DECLARE 块中")
+	}
+
+	// 检查是否包含正确的变量声明
+	if !strings.Contains(result, "v_dec_high DECIMAL") && !strings.Contains(result, "v_dec_high NUMERIC") {
+		t.Error("缺少 v_dec_high 变量声明")
+	}
+
+	if !strings.Contains(result, "v_ratio NUMERIC") && !strings.Contains(result, "v_ratio DECIMAL") {
+		t.Error("缺少 v_ratio 变量声明")
+	}
+}
+
+// TestFunctionCursorClose 测试游标 CLOSE 语句处理
+// 复现错误：func_001_complex_analysis 的 CLOSE cur_complex 被错误处理为 cur_complex;
+func TestFunctionCursorClose(t *testing.T) {
+	mysqlDDL := `CREATE FUNCTION func_001_complex_analysis(param_limit INT) RETURNS TEXT
+READS SQL DATA
+BEGIN
+    DECLARE done INT DEFAULT FALSE;
+    DECLARE v_result TEXT DEFAULT '';
+    DECLARE v_counter INT DEFAULT 0;
+    DECLARE cur_complex CURSOR FOR
+        SELECT id FROM case_01_integers LIMIT param_limit;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+    OPEN cur_complex;
+    read_loop: LOOP
+        FETCH cur_complex INTO v_result;
+        IF done THEN
+            LEAVE read_loop;
+        END IF;
+        SET v_counter = v_counter + 1;
+    END LOOP;
+    CLOSE cur_complex;
+
+    RETURN v_result;
+END`
+
+	result, err := ConvertFunctionDDL(mysql.FunctionInfo{
+		Name: "func_001_complex_analysis",
+		DDL:  mysqlDDL,
+	})
+
+	if err != nil {
+		t.Fatalf("转换失败：%v", err)
+	}
+
+	t.Logf("转换结果:\n%s", result)
+
+	// 检查是否有正确的 CLOSE 语句
+	if !strings.Contains(result, "CLOSE cur_complex") {
+		t.Error("缺少 CLOSE cur_complex 语句")
+	}
+
+	// 检查是否有错误的孤立游标名称
+	if strings.Contains(result, "END LOOP;\ncur_complex") || strings.Contains(result, "END LOOP; cur_complex") {
+		t.Error("游标名称错误地出现在 END LOOP 之后，应该是 CLOSE 语句")
+	}
+}
+
+// TestFunctionNumericTypeInDeclare 测试 NUMERIC 类型在 DECLARE 中的处理
+func TestFunctionNumericTypeInDeclare(t *testing.T) {
+	mysqlDDL := `CREATE FUNCTION test_numeric_declare(_id BIGINT)
+RETURNS VARCHAR(16)
+READS SQL DATA
+BEGIN
+    DECLARE v_ratio NUMERIC(20,10) DEFAULT 0;
+    SELECT ratio INTO v_ratio FROM test_table WHERE id = _id;
+    RETURN 'LOW';
+END`
+
+	result, err := ConvertFunctionDDL(mysql.FunctionInfo{
+		Name: "test_numeric_declare",
+		DDL:  mysqlDDL,
+	})
+
+	if err != nil {
+		t.Fatalf("转换失败：%v", err)
+	}
+
+	t.Logf("转换结果:\n%s", result)
+
+	// 检查 NUMERIC 类型是否被正确保留
+	if !strings.Contains(result, "NUMERIC(20,10)") && !strings.Contains(result, "DECIMAL(20,10)") {
+		t.Error("NUMERIC(20,10) 类型没有被正确转换")
+	}
+}
+
+// 辅助函数：打印转换结果的调试信息
+func debugConversionResult(t *testing.T, name, ddl string) {
+	result, err := ConvertFunctionDDL(mysql.FunctionInfo{
+		Name: name,
+		DDL:  ddl,
+	})
+	if err != nil {
+		t.Logf("转换 %s 失败：%v", name, err)
+		return
+	}
+	t.Logf("=== %s 转换结果 ===", name)
+	t.Logf("%s", result)
+	t.Logf("=== END ===")
+}
+
+func TestDebugFunctionConversion(t *testing.T) {
+	// 从 create_function.sql 中读取实际函数进行测试
+	t.Run("func_110_case_daily_numeric_risk_tag", func(t *testing.T) {
+		mysqlDDL := `CREATE FUNCTION func_110_case_daily_numeric_risk_tag(_id BIGINT UNSIGNED)
+RETURNS VARCHAR(16)
+READS SQL DATA
+BEGIN
+    DECLARE v_dec_high DECIMAL(65,30) DEFAULT 0;
+    DECLARE v_ratio NUMERIC(20,10) DEFAULT 0;
+    SELECT IFNULL(dec_high, 0), IFNULL(ratio, 0)
+      INTO v_dec_high, v_ratio
+    FROM case_160_numeric_boundary
+    WHERE id = _id
+    LIMIT 1;
+    IF v_dec_high >= 1000000000000 OR v_ratio >= 100000 THEN
+        RETURN 'HIGH';
+    ELSEIF v_dec_high >= 1000000 OR v_ratio >= 1000 THEN
+        RETURN 'MEDIUM';
+    END IF;
+    RETURN 'LOW';
+END`
+		debugConversionResult(t, "func_110_case_daily_numeric_risk_tag", mysqlDDL)
+	})
+
+	t.Run("func_001_complex_analysis", func(t *testing.T) {
+		mysqlDDL := `CREATE FUNCTION func_001_complex_analysis(param_limit INT) RETURNS TEXT
+READS SQL DATA
+BEGIN
+    DECLARE done INT DEFAULT FALSE;
+    DECLARE v_result TEXT DEFAULT '';
+    DECLARE v_counter INT DEFAULT 0;
+    DECLARE cur_complex CURSOR FOR
+        SELECT id FROM case_01_integers LIMIT param_limit;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+    OPEN cur_complex;
+    read_loop: LOOP
+        FETCH cur_complex INTO v_result;
+        IF done THEN
+            LEAVE read_loop;
+        END IF;
+        SET v_counter = v_counter + 1;
+    END LOOP;
+    CLOSE cur_complex;
+
+    RETURN v_result;
+END`
+		debugConversionResult(t, "func_001_complex_analysis", mysqlDDL)
+	})
+}

--- a/internal/converter/postgres/sync_functions.go
+++ b/internal/converter/postgres/sync_functions.go
@@ -84,8 +84,8 @@ var (
 	reEndIfIf         = regexp.MustCompile(`(?i)END\s+IF;\s*END\s+IF;`)
 	reEndLoopLoop     = regexp.MustCompile(`(?i)END\s+LOOP;\s*END\s+LOOP;`)
 	reTooManyEnds     = regexp.MustCompile(`(?i)(end\s+){3,}`)
-	// 增强变量声明匹配，支持更多类型和格式
-	reVarDecl = regexp.MustCompile(`(?i)\s*(\w+)\s+(INT|VARCHAR|TEXT|DECIMAL|DATE|TIME|TIMESTAMP|BOOLEAN|FLOAT|DOUBLE|CHAR|REFCURSOR|TINYINT|BIGINT|MEDIUMINT|SMALLINT)\s*(?:UNSIGNED)?\s*(?:\((\d+(?:,\d+)?)\))?\s*(?:DEFAULT\s+([^;]+))?;`)
+	// 增强变量声明匹配，支持更多类型和格式（包括 NUMERIC）
+	reVarDecl = regexp.MustCompile(`(?i)\s*(\w+)\s+(INT|VARCHAR|TEXT|DECIMAL|NUMERIC|DATE|TIME|TIMESTAMP|BOOLEAN|FLOAT|DOUBLE|CHAR|REFCURSOR|TINYINT|BIGINT|MEDIUMINT|SMALLINT)\s*(?:UNSIGNED)?\s*(?:\((\d+(?:,\d+)?)\))?\s*(?:DEFAULT\s+([^;]+))?;`)
 
 	// 基础清理相关
 	reBegin           = regexp.MustCompile(`(?i)BEGIN\s*`)
@@ -133,7 +133,7 @@ var (
 	reRowCountAssign = regexp.MustCompile(`(?i)(\w+)\s*:=\s*ROW_COUNT\(\)\s*;?`)
 	reDoneEqTrue     = regexp.MustCompile(`(?i)\bdone\s*=\s*1\b`)
 	reDoneEqFalse    = regexp.MustCompile(`(?i)\bdone\s*=\s*0\b`)
-	reEndLoopTail    = regexp.MustCompile(`(?i)\bEND\s+LOOP\s*;\s*[A-Za-z_][A-Za-z0-9_]*`)
+	reEndLoopTail    = regexp.MustCompile(`(?i)\bEND\s+LOOP\s+[A-Za-z_][A-Za-z0-9_]*\s*;`)
 	reIdentifierOnly = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 	// 类型修饰符清理
@@ -1162,7 +1162,7 @@ func (c *FunctionConverter) handleVariables() {
 
 			// 构建 PG 声明
 			varDecl := varName + " " + pgType
-			if (pgType == "VARCHAR" || pgType == "CHAR" || pgType == "DECIMAL") && varSize != "" {
+			if (pgType == "VARCHAR" || pgType == "CHAR" || pgType == "DECIMAL" || pgType == "NUMERIC") && varSize != "" {
 				varDecl += fmt.Sprintf("(%s)", varSize)
 			}
 			if varDefault != "" {


### PR DESCRIPTION
- 在 reVarDecl 正则中添加 NUMERIC 类型支持，修复 NUMERIC(20,10) 等精度声明无法识别的问题
- 修复 reEndLoopTail 正则表达式，从  改为 ，避免错误移除  中的 CLOSE 语句
- 在 handleVariables 函数中添加 NUMERIC 类型的精度支持，确保 NUMERIC(20,10) 等声明能保留精度信息
- 添加单元测试验证变量声明顺序、游标 CLOSE 语句和 NUMERIC 类型转换的正确性

修复的错误日志：
- ERROR: syntax error at or near 'v_ratio' - 变量声明在 BEGIN 之后而不是 DECLARE 块中
- ERROR: mismatched parentheses at or near ';' - CLOSE 语句被错误移除