### PR TITLE
ci: 添加 MySQL 5.7+/8.0 到 PostgreSQL 12-18 版本兼容性测试

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -73,6 +73,10 @@ jobs:
             image: 'postgres:14'
           - version: '16'
             image: 'postgres:16'
+          - version: '17'
+            image: 'postgres:17'
+          - version: '18'
+            image: 'postgres:18'
         # Exclude incompatible combinations if any
         exclude:
           # All combinations are supported

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,14 +53,32 @@ jobs:
           name: coverage-report
           path: coverage.out
 
-  # ===== Integration Tests =====
+  # ===== Integration Tests - Version Compatibility Matrix =====
   integration-test:
-    name: Integration Tests
+    name: Integration Tests (MySQL ${{ matrix.mysql.version }} → PG ${{ matrix.postgres.version }})
     runs-on: ubuntu-latest
     needs: unit-test
+    strategy:
+      fail-fast: false
+      matrix:
+        mysql:
+          - version: '5.7'
+            image: 'mysql:5.7'
+          - version: '8.0'
+            image: 'mysql:8.0'
+        postgres:
+          - version: '12'
+            image: 'postgres:12'
+          - version: '14'
+            image: 'postgres:14'
+          - version: '16'
+            image: 'postgres:16'
+        # Exclude incompatible combinations if any
+        exclude:
+          # All combinations are supported
     services:
       mysql:
-        image: mysql:8.0
+        image: ${{ matrix.mysql.image }}
         env:
           MYSQL_ROOT_PASSWORD: rootpassword
           MYSQL_DATABASE: test_db
@@ -72,7 +90,7 @@ jobs:
           --health-timeout=5s
           --health-retries=10
       postgres:
-        image: postgres:16
+        image: ${{ matrix.postgres.image }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgrespassword
@@ -197,6 +215,7 @@ jobs:
 
       - name: Run MySQL2PG
         run: |
+          echo "=== Running MySQL2PG: MySQL ${{ matrix.mysql.version }} → PostgreSQL ${{ matrix.postgres.version }} ==="
           go build -o mysql2pg ./cmd/
           ./mysql2pg -c config.yml
 
@@ -204,7 +223,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-test-logs
+          name: integration-test-logs-mysql${{ matrix.mysql.version }}-pg${{ matrix.postgres.version }}
           path: |
             conversion.log
             errors.log


### PR DESCRIPTION
## 变更说明

本 PR 添加了完整的版本兼容性测试矩阵，确保 MySQL2PG 在多个数据库版本组合下的兼容性。

### 测试矩阵

**MySQL 版本：**
- MySQL 5.7
- MySQL 8.0

**PostgreSQL 版本：**
- PostgreSQL 12
- PostgreSQL 14
- PostgreSQL 16
- PostgreSQL 17
- PostgreSQL 18

### 测试组合数

共 **10 种组合** (2 × 5)，使用 GitHub Actions 矩阵策略并行运行。

### 主要改动

- 添加 `strategy.matrix` 配置，动态测试多版本组合
- 动态显示测试任务名称：`Integration Tests (MySQL X.X → PG X.X)`
- 按版本区分上传日志工件：`integration-test-logs-mysqlXX-pgXX`
- 设置 `fail-fast: false`，确保所有版本组合都会运行完成

### 预期效果

CI 会自动在 PR 上运行所有 10 种版本组合的集成测试，确保迁移工具在不同数据库版本下的兼容性。
