### PR TITLE
fix: 注释 MySQL 8.0+ 专用的 REGEXP 函数视图以兼容 MySQL 5.7

### DIFF
--- a/scripts/mysql/create_view.sql
+++ b/scripts/mysql/create_view.sql
@@ -426,8 +426,10 @@ FROM
 -- 视图 21：使用 MySQL 8.0 的正则表达式函数（MySQL 8.0+）
 -- 注意：REGEXP_REPLACE, REGEXP_INSTR, REGEXP_SUBSTR 是 MySQL 8.0+ 特有函数
 -- PostgreSQL 12+ 支持 regexp_replace()，但 REGEXP_INSTR/SUBSTR 需要转换
+-- 已注释：MySQL 5.7 不支持这些函数，仅用于 MySQL 8.0+ 测试
+/****
 CREATE OR REPLACE VIEW view_case25_mysql8_regexp AS
-SELECT 
+SELECT
     c1,
     c2,
     c3,
@@ -435,13 +437,14 @@ SELECT
     c5,
     c6,
     (c1 RLIKE '^[A-Za-z]+$') AS is_alpha_c1,  -- RLIKE → ~ (PostgreSQL 正则匹配)
-    (c2 RLIKE '^[0-9]+$') AS is_numeric_c2,   -- RLIKE → ~
+    (c2 RLIKE '^[0-9]+') AS is_numeric_c2,   -- RLIKE → ~
     REGEXP_REPLACE(c3, '[0-9]+', '#') AS cleaned_c3,  -- REGEXP_REPLACE → regexp_replace()
     REGEXP_INSTR(c4, 'test') AS test_pos_c4,  -- REGEXP_INSTR → CASE WHEN ~ THEN 1 ELSE 0
     REGEXP_SUBSTR(c5, '[A-Za-z]+') AS numbers_c5,  -- REGEXP_SUBSTR → SUBSTRING(from pattern)
     LENGTH(c6) - LENGTH(REPLACE(c6, 'a', '')) AS a_count_c6  -- 模拟 REGEXP_COUNT
-FROM 
+FROM
     case_05_charsets;
+****/
 
 -- 视图22：使用MySQL 8.0的GIS空间函数
 /****


### PR DESCRIPTION
- REGEXP_REPLACE, REGEXP_INSTR, REGEXP_SUBSTR 是 MySQL 8.0+ 特有函数
- MySQL 5.7 不支持这些函数，会导致 'FUNCTION does not exist' 错误
- 使用 /**** ... ****/ 注释掉 view_case25_mysql8_regexp 视图
- 这个视图仅用于测试 MySQL 8.0+ 的正则表达式功能