### PR TITLE
Xfg0218

### DIFF
--- a/QWEN.md
+++ b/QWEN.md
@@ -389,7 +389,7 @@ Report is a single self-contained HTML file with inline CSS and Google Fonts —
 | `int`, `int(11)`, `integer` | `INTEGER` | All int variants |
 | `mediumint`, `mediumint(9)` | `INTEGER` | |
 | `smallint`, `smallint(6)` | `SMALLINT` | All smallint variants |
-| `tinyint(1)` | `BOOLEAN` | Special case |
+| `tinyint(1)` | `SMALLINT`（默认）/ `BOOLEAN`（`tinyint1_as_boolean: true`） | 默认保留整数语义，兼容视图/函数中 `col = 1` 用法（PG 无 boolean = integer 运算符） |
 | `tinyint`, `tinyint(4)` | `SMALLINT` | Other tinyint variants |
 | `decimal`, `numeric` | `DECIMAL` | Preserves precision |
 | `double`, `double precision` | `DOUBLE PRECISION` | |

--- a/QWEN.md
+++ b/QWEN.md
@@ -300,16 +300,18 @@ Step 6: Convert functions (functions: true)
   └─ Execute CREATE FUNCTION statements in PostgreSQL
 
 Step 7: Convert users (users: true)
-  └─ MySQL Users → PostgreSQL Roles (preserve password hashes)
+  └─ MySQL Users → PostgreSQL Roles (passwords are not migrated: hash formats
+     are incompatible; a reset list with ALTER USER templates is output)
 
 Step 8: Convert table privileges (table_privileges: true)
   └─ GRANT statements converted to PostgreSQL equivalents
 
 Final Step: Data validation & Completion (validate_data: true)
   ├─ Compare row counts: MySQL vs PostgreSQL
-  ├─ Re-enable foreign key constraints and indexes
   ├─ Report inconsistent tables (if truncate_before_sync=false, continues)
   └─ Output conversion statistics and performance metrics
+  (no FK/index disabling happens during sync: FKs are not migrated yet and
+   secondary indexes are created after data sync)
 ```
 
 ## HTML Report Structure

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Start
  │     └─ If use_table_list=true → Only fetch tables in table_list
  │
  ├─▶ [Step 2] Convert table structures (tableddl: true)
- │     ├─ Intelligent field type mapping (e.g., tinyint(1) → BOOLEAN)
+ │     ├─ Intelligent field type mapping (e.g., tinyint(1) → SMALLINT, or BOOLEAN via tinyint1_as_boolean)
  │     ├─ lowercase_columns controls field name casing
  │     ├─ Extract primary key columns for MPP distribution key
  │     ├─ If MPP enabled (conversion.mpp.enabled=true):
@@ -332,7 +332,7 @@ Supports conversion of 40+ MySQL field types to PostgreSQL compatible types, wit
 | int, int(11), integer, etc.  | INTEGER            | All int variants to INTEGER                             |
 | mediumint, mediumint(9)      | INTEGER            | mediumint to INTEGER                                    |
 | smallint, smallint(6), etc.  | SMALLINT           | All smallint variants to SMALLINT                       |
-| tinyint(1)                   | BOOLEAN            | tinyint(1) to BOOLEAN                                   |
+| tinyint(1)                   | SMALLINT (default) / BOOLEAN | Default SMALLINT keeps integer semantics (views/functions using `col = 1` stay valid); set `tinyint1_as_boolean: true` for BOOLEAN |
 | tinyint, tinyint(4), etc.    | SMALLINT           | Other tinyint variants to SMALLINT                      |
 | decimal, numeric             | DECIMAL            | decimal kept as DECIMAL, preserving precision           |
 | double, double precision     | DOUBLE PRECISION   | double to DOUBLE PRECISION                              |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Start
  │
  ├─▶ [Step 2] Convert table structures (tableddl: true)
  │     ├─ Intelligent field type mapping (e.g., tinyint(1) → BOOLEAN)
- │     ├─ lowercase_columns/lowercase_tables controls field/table name casing
+ │     ├─ lowercase_columns controls field name casing
  │     ├─ Extract primary key columns for MPP distribution key
  │     ├─ If MPP enabled (conversion.mpp.enabled=true):
  │     │   └─ Add DISTRIBUTED BY (pk_col1, pk_col2, ...) clause
@@ -48,7 +48,9 @@ Start
  │
  ├─▶ [Step 3] Convert views (views: true)
  │     ├─ If exclude_use_view_list=true → Filter out views in exclude_view_list
- │     └─ Convert MySQL view definitions to PostgreSQL compatible syntax
+ │     ├─ Convert MySQL view definitions to PostgreSQL compatible syntax
+ │     └─ Note: identifiers in view definitions (including the view name) are
+ │        always lowercased; string literal content is preserved (P2-13 convention)
  │
  ├─▶ [Step 4] Sync data (data: true)
  │     ├─ If truncate_before_sync=true → Truncate target tables

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Start
  │
  ├─▶ [Step 4] Sync data (data: true)
  │     ├─ If truncate_before_sync=true → Truncate target tables
- │     ├─ Batch read MySQL data (max_rows_per_batch)
+ │     ├─ Batch read MySQL data (max_rows_per_batch, auto-scaled down for wide tables)
  │     ├─ Batch insert into PostgreSQL (batch_insert_size)
- │     ├─ Concurrency controlled by concurrency parameter
- │     └─ Automatically disable foreign key constraints and indexes for performance
+ │     └─ Concurrency controlled by concurrency parameter
+ │        (no FK/index disabling: FKs are not migrated yet — see roadmap;
+ │         secondary indexes are created after data sync)
  │
  ├─▶ [Step 5] Convert indexes (indexes: true)
  │     ├─ If MPP enabled (Greenplum):
@@ -78,7 +79,6 @@ Start
  │
  └─▶ [Final Step] Data validation & Completion (validate_data: true)
        ├─ Query row counts for MySQL and PostgreSQL tables
-       ├─ Re-enable previously disabled foreign key constraints and indexes
        ├─ If truncate_before_sync=false → Log inconsistent tables, continue execution
        ├─ Output conversion statistics report and performance metrics
        └─ Generate inconsistent table list (if any)

--- a/README_CN.md
+++ b/README_CN.md
@@ -40,7 +40,7 @@ MySQL2PG是一款用Go语言开发的专业级数据库转换工具，专注于�
  │     └─ 若 use_table_list=true → 仅获取 table_list 中的表
  │
  ├─▶ [Step 2] 转换表结构 (tableddl: true)
- │     ├─ 字段类型智能映射（如 tinyint(1) → BOOLEAN）
+ │     ├─ 字段类型智能映射（如 tinyint(1) → SMALLINT，可选 tinyint1_as_boolean 转 BOOLEAN）
  │     ├─ lowercase_columns 控制字段名大小写
  │     ├─ 提取主键列作为 MPP 分布键
  │     ├─ 若启用 MPP（conversion.mpp.enabled=true）:
@@ -293,7 +293,7 @@ MySQL2PG是一款用Go语言开发的专业级数据库转换工具，专注于�
 | int, int(11), int(4), int(2), int(5), int(10), int(20), int(255), int(32), int(8), int(60), int(3), int(25), int(22), integer | INTEGER | 所有int变体统一转换为INTEGER |
 | mediumint, mediumint(9) | INTEGER | mediumint转换为INTEGER |
 | smallint, smallint(6), smallint(1), smallinteger | SMALLINT | 所有smallint变体统一转换为SMALLINT |
-| tinyint(1) | BOOLEAN | tinyint(1)转换为BOOLEAN（布尔值） |
+| tinyint(1) | SMALLINT（默认）/ BOOLEAN | 默认转 SMALLINT 保留整数语义（视图/函数中 `col = 1` 等用法保持有效）；设置 `tinyint1_as_boolean: true` 转 BOOLEAN |
 | tinyint, tinyint(4), tinyint(255), tinyinteger | SMALLINT | 其他tinyint变体转换为SMALLINT |
 | decimal, decimal(10,0), decimal(10,2), numeric | DECIMAL | decimal保持为DECIMAL，保留精度 |
 | double, double precision | DOUBLE PRECISION | double转换为DOUBLE PRECISION |

--- a/README_CN.md
+++ b/README_CN.md
@@ -49,7 +49,9 @@ MySQL2PG是一款用Go语言开发的专业级数据库转换工具，专注于�
  │
  ├─▶ [Step 3] 转换视图 (view: true)
  │     ├─ 若 exclude_use_view_list=true → 跳过 exclude_view_list 中的视图
- │     └─ MySQL 视图定义转换为 PostgreSQL 兼容语法
+ │     ├─ MySQL 视图定义转换为 PostgreSQL 兼容语法
+ │     └─ 注意：视图定义中的标识符（含视图名）统一转为小写，
+ │        字符串字面量内容不受影响（P2-13 约定）
  │
  ├─▶ [Step 4] 同步数据 (data: true)
  │     ├─ 若 truncate_before_sync=true → 清空目标表

--- a/README_CN.md
+++ b/README_CN.md
@@ -55,10 +55,11 @@ MySQL2PG是一款用Go语言开发的专业级数据库转换工具，专注于�
  │
  ├─▶ [Step 4] 同步数据 (data: true)
  │     ├─ 若 truncate_before_sync=true → 清空目标表
- │     ├─ 分批读取 MySQL 数据（max_rows_per_batch）
+ │     ├─ 分批读取 MySQL 数据（max_rows_per_batch，宽表按估算行宽自适应下调）
  │     ├─ 批量插入 PostgreSQL（batch_insert_size）
- │     ├─ 并发线程数由 concurrency 控制
- │     └─ 自动禁用外键约束和索引提高性能
+ │     └─ 并发线程数由 concurrency 控制
+ │        （无外键/索引禁用动作：外键尚未迁移——见路线图；
+ │         二级索引在数据同步之后创建）
  │
  ├─▶ [Step 5] 转换索引 (indexes: true)
  │     ├─ 若 MPP 启用（Greenplum）:
@@ -79,7 +80,6 @@ MySQL2PG是一款用Go语言开发的专业级数据库转换工具，专注于�
  │
  └─▶ [Final Step] 数据校验与完成 (validate_data: true)
        ├─ 查询 MySQL 和 PostgreSQL 表行数
-       ├─ 重新启用之前禁用的外键约束和索引
        ├─ 若 truncate_before_sync=false → 记录不一致表，继续执行
        ├─ 输出转换统计报告和性能指标
        └─ 生成不一致表清单（如有）

--- a/config.example.yml
+++ b/config.example.yml
@@ -36,6 +36,8 @@ conversion:
     users: true       # 转换用户
     table_privileges: true # 转换用户在表上的权限
     lowercase_columns: true     # 控制表字段是否需要转小写，true为转小写（默认值），false保持与MySQL字段一致
+                                # 注意：视图 DDL 中的标识符（含视图名）始终整体转小写，
+                                # 与本选项无关，字符串字面量内容不受影响（P2-13 约定）
     skip_existing_tables: true  # 如果表在PostgreSQL中已存在，true 为跳过，false 为创建
     validate_data: true         # 同步数据后验证数据一致性
     truncate_before_sync: false  # 同步前是否清空表数据

--- a/config.example.yml
+++ b/config.example.yml
@@ -41,6 +41,9 @@ conversion:
     skip_existing_tables: true  # 如果表在PostgreSQL中已存在，true 为跳过，false 为创建
     validate_data: true         # 同步数据后验证数据一致性
     truncate_before_sync: false  # 同步前是否清空表数据
+    tinyint1_as_boolean: false  # tinyint(1) 映射策略：false（默认）→ SMALLINT，保留整数语义，
+                                # 兼容视图/函数中 `col = 1`、COALESCE(col, 0) 等用法；
+                                # true → BOOLEAN（布尔语义，需确保无布尔列与整数的比较/算术）
     use_table_list: false       # 是否使用指定的表列表进行数据同步，其他步骤不生效
     table_list: [table1]  # 指定要同步的表列表，当use_table_list为true时生效，格式为[table1,table2,...]
     exclude_use_table_list: false   # 是否使用跳过表列表，为true时不同步exclude_table_list中的表

--- a/config.example.yml
+++ b/config.example.yml
@@ -63,8 +63,8 @@ conversion:
     max_functions_per_batch: 5  # 一次性转换function的个数限制
     max_indexes_per_batch: 20   # 一次性转换index的个数限制
     max_users_per_batch: 10     # 一次性转换用户的个数限制
-    max_rows_per_batch: 1000    # 一次性同步数据的行数限制
-    batch_insert_size: 1000     # 批量插入的大小
+    max_rows_per_batch: 50000   # 一次性同步数据的行数限制（宽表会按估算行宽自适应下调）
+    batch_insert_size: 50000    # 批量插入的大小（建议与 max_rows_per_batch 保持一致）
 
 # 运行配置
 run:

--- a/internal/assessor/manager.go
+++ b/internal/assessor/manager.go
@@ -431,7 +431,9 @@ func (a *Assessor) assessObjects() {
 		if tableDDL, err := a.mysqlConn.GetTableDDL(a.context(), table.Name); err == nil {
 			ddl = tableDDL
 			// 尝试使用现有转换函数进行转换，评估兼容性
-			result, err := postgres.ConvertTableDDL(ddl, a.config.Conversion.Options.LowercaseColumns)
+			result, err := postgres.ConvertTableDDL(ddl, a.config.Conversion.Options.LowercaseColumns, postgres.ConvertTableDDLOptions{
+				TinyInt1AsBoolean: a.config.Conversion.Options.TinyInt1AsBoolean,
+			})
 			if err != nil {
 				// 转换失败，记录为高风险
 				table.Risks = append(table.Risks, Risk{

--- a/internal/assessor/migration_assessor.go
+++ b/internal/assessor/migration_assessor.go
@@ -287,7 +287,9 @@ func (a *MigrationAssessor) assessTablesWithMigrationLogic() {
 		}
 
 		// 使用现有 ConvertTableDDL 函数进行转换评估
-		_, err = postgres.ConvertTableDDL(ddl, a.config.Conversion.Options.LowercaseColumns)
+		_, err = postgres.ConvertTableDDL(ddl, a.config.Conversion.Options.LowercaseColumns, postgres.ConvertTableDDLOptions{
+			TinyInt1AsBoolean: a.config.Conversion.Options.TinyInt1AsBoolean,
+		})
 		if err != nil {
 			table.Risks = append(table.Risks, Risk{
 				Level:       RiskLevelHigh,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,12 @@ type OptionsConfig struct {
 	ValidateData       bool     `mapstructure:"validate_data"`          // 同步后验证数据一致性
 	LowercaseColumns   bool     `mapstructure:"lowercase_columns"`      // 表字段是否转小写，true代表转小写，默认，false代表与mysql一致
 	TruncateBeforeSync bool     `mapstructure:"truncate_before_sync"`   // 同步前是否清空表数据
+	// tinyint(1) 映射策略：MySQL 的 tinyint(1) 虽是布尔惯例但本质是整数，
+	// 视图/函数中广泛存在 `col = 1`、`COALESCE(col, 0)` 等用法，映射为 PG BOOLEAN
+	// 会因 boolean = integer 无对应运算符而报 42883。
+	// 默认 false：tinyint(1) -> SMALLINT，保留整数语义、视图/函数完全兼容；
+	// 显式 true：映射为 BOOLEAN，需自行确保无布尔列与整数的比较/算术
+	TinyInt1AsBoolean bool `mapstructure:"tinyint1_as_boolean"`
 
 	// 视图排除列表
 	SkipUseViewList bool      `mapstructure:"exclude_use_view_list"` // 是否使用视图排除列表

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -236,6 +236,9 @@ func (c *Config) ValidateConfig() error {
 	if c.Conversion.Limits.MaxRowsPerBatch <= 0 {
 		c.Conversion.Limits.MaxRowsPerBatch = 50000 // 默认值，与 BatchInsertSize 保持一致以减少网络往返
 	}
+	if c.Conversion.Limits.BatchInsertSize <= 0 {
+		c.Conversion.Limits.BatchInsertSize = 50000 // 默认值，与 MaxRowsPerBatch 对齐，避免读 50000 行却按 10000 行分块插入
+	}
 
 	// MPP 配置默认值
 	if c.Conversion.MPP.Database == "" {

--- a/internal/converter/postgres/manager.go
+++ b/internal/converter/postgres/manager.go
@@ -1660,7 +1660,10 @@ func (m *Manager) convertIndexes(indexes []mysql.IndexInfo, semaphore chan struc
 		}
 		// ========== MPP 处理结束 ==========
 
-		pgDDL, err := ConvertIndexDDL(index.Table, index, m.config.Conversion.Options.LowercaseColumns, columnNamesMap)
+		pgDDL, indexWarnings, err := ConvertIndexDDL(index, m.config.Conversion.Options.LowercaseColumns, columnNamesMap)
+		for _, w := range indexWarnings {
+			m.RecordConversionWarning("索引", index.Table, fmt.Sprintf("%s: %s", index.Name, w))
+		}
 		if err != nil {
 			errMsg := fmt.Sprintf("转换索引 %s 失败: %v", lowercaseIndexName, err)
 			m.logError(errMsg)
@@ -1669,7 +1672,7 @@ func (m *Manager) convertIndexes(indexes []mysql.IndexInfo, semaphore chan struc
 			return err
 		}
 
-		// 如果没有生成DDL语句（比如只包含pri_key的索引），则跳过
+		// 如果没有生成DDL语句（比如只包含pri_key的索引、被跳过的函数/SPATIAL索引），则跳过
 		if pgDDL == "" {
 			<-semaphore
 			m.updateProgress()

--- a/internal/converter/postgres/manager.go
+++ b/internal/converter/postgres/manager.go
@@ -1597,6 +1597,11 @@ func (m *Manager) convertFunctions(functions []mysql.FunctionInfo, semaphore cha
 			m.RecordConversionWarning("函数语法", function.Name,
 				"包含 DECLARE HANDLER 错误处理：NOT FOUND 语义已转为 IF NOT FOUND，其他 HANDLER 以注释保留，请人工复核")
 		}
+		// P2-16：SIGNAL/RESIGNAL 抛错语义转换提示（RESIGNAL 子串含 SIGNAL，一并覆盖）
+		if strings.Contains(strings.ToUpper(function.DDL), "SIGNAL") {
+			m.RecordConversionWarning("函数语法", function.Name,
+				"包含 SIGNAL/RESIGNAL 抛错语句：SIGNAL 已转为 RAISE EXCEPTION，RESIGNAL 转为 RAISE，错误处理语义请人工复核")
+		}
 
 		// 更新进度
 		completed := m.completeTask()

--- a/internal/converter/postgres/manager.go
+++ b/internal/converter/postgres/manager.go
@@ -1331,7 +1331,10 @@ func (m *Manager) convertTables(tables []mysql.TableInfo, semaphore chan struct{
 			distByCols = extractPrimaryKeyColumnsFromDDL(table.DDL)
 		}
 
-		pgResult, err := ConvertTableDDL(table.DDL, m.config.Conversion.Options.LowercaseColumns, distByCols...)
+		pgResult, err := ConvertTableDDL(table.DDL, m.config.Conversion.Options.LowercaseColumns, ConvertTableDDLOptions{
+			TinyInt1AsBoolean:    m.config.Conversion.Options.TinyInt1AsBoolean,
+			DistributedByColumns: distByCols,
+		})
 		if err != nil {
 			// 记录转换失败的 MySQL 表的部分转换结果
 			m.Log("转换表 %s，MySQL DDL: %s", table.Name, table.DDL)

--- a/internal/converter/postgres/manager.go
+++ b/internal/converter/postgres/manager.go
@@ -1797,8 +1797,13 @@ func (m *Manager) syncTableData(tables []mysql.TableInfo, semaphore chan struct{
 	)
 }
 
-// convertTablePrivileges 转换表权限
+// convertTablePrivileges 旧 grant 选项的表权限入口（已废弃，P2-09）：
+// 此前仅以 time.Sleep 模拟成功、不做任何授权。真实的表权限转换由
+// table_privileges 选项驱动的 convertTablePrivilegesNew 完成。
+// 保留进度计数语义，但如实报告未执行任何转换
 func (m *Manager) convertTablePrivileges(tables []mysql.TableInfo, semaphore chan struct{}) error {
+	m.RecordConversionWarning("权限", "*",
+		"grant 选项已废弃且从未实现真实转换，本次未执行任何表级授权；请改用 conversion.options.table_privileges")
 	for _, table := range tables {
 		// 取消检查：根 context 取消后停止处理后续表权限
 		if err := m.context().Err(); err != nil {
@@ -1806,20 +1811,18 @@ func (m *Manager) convertTablePrivileges(tables []mysql.TableInfo, semaphore cha
 		}
 
 		semaphore <- struct{}{}
-		// 模拟权限转换
-		time.Sleep(100 * time.Millisecond)
 
 		// 更新进度
 		completed := m.completeTask()
 		progress := float64(completed) / float64(m.totalTasks) * 100
 
-		// 显示转换成功信息（根据配置决定是否在控制台显示）
+		// 显示转换信息（根据配置决定是否在控制台显示）
 		if m.config.Run.ShowConsoleLogs {
-			fmt.Printf("进度: %.2f%% (%d/%d) : 转换表 %s 的权限成功\n", progress, completed, m.totalTasks, table.Name)
+			fmt.Printf("进度: %.2f%% (%d/%d) : 跳过表 %s 的权限（grant 选项已废弃，请使用 table_privileges）\n", progress, completed, m.totalTasks, table.Name)
 		}
 
 		// 记录到日志文件
-		m.Log("转换表 %s 的权限成功", table.Name)
+		m.Log("跳过表 %s 的权限转换（grant 选项已废弃，请使用 table_privileges）", table.Name)
 
 		<-semaphore
 	}
@@ -1868,8 +1871,12 @@ func (m *Manager) convertTablePrivilegesNew(tablePrivileges []mysql.TablePrivInf
 			continue
 		}
 
-		// 转换表权限
-		pgDDLs, err := ConvertTablePrivilegeDDL(tablePriv)
+		// 转换表权限（P2-09：GRANT 指向 schema 限定的表，与用户权限路径一致）
+		privilegeCtx := PrivilegeContext{
+			Database: m.config.PostgreSQL.Database,
+			Schema:   mpp.ParseSearchPath(m.postgresConn.GetPgConnectionParams()),
+		}
+		pgDDLs, err := ConvertTablePrivilegeDDL(tablePriv, privilegeCtx)
 		if err != nil {
 			errMsg := fmt.Sprintf("转换表权限失败: %v", err)
 			m.logError(errMsg)
@@ -2069,11 +2076,23 @@ func (m *Manager) RecordConversionWarning(category, object, detail string) {
 	m.mutex.Unlock()
 }
 
-// displayConversionWarnings 显示转换降级/丢弃清单（P1-20）
+// displayConversionWarnings 显示转换降级/丢弃清单（P1-20）。
+// 按 类别+对象+说明 去重并保持顺序：分批处理的路径（如废弃的 grant 选项）
+// 可能对同一事实重复记录
 func (m *Manager) displayConversionWarnings() {
 	m.mutex.Lock()
-	warnings := append([]ConversionWarning(nil), m.conversionWarnings...)
+	collected := append([]ConversionWarning(nil), m.conversionWarnings...)
 	m.mutex.Unlock()
+
+	seen := make(map[string]bool)
+	var warnings []ConversionWarning
+	for _, w := range collected {
+		key := w.Category + "\x00" + w.Object + "\x00" + w.Detail
+		if !seen[key] {
+			seen[key] = true
+			warnings = append(warnings, w)
+		}
+	}
 	if len(warnings) == 0 {
 		return
 	}

--- a/internal/converter/postgres/sync_batch_e_test.go
+++ b/internal/converter/postgres/sync_batch_e_test.go
@@ -106,8 +106,67 @@ func TestFunctionHandlerConversion(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ConvertFunctionDDL 返回错误：%v", err)
 		}
-		if !strings.Contains(out, "-- [mysql2pg] MySQL HANDLER 无法自动转换") {
+		if !strings.Contains(out, "/* [mysql2pg] MySQL HANDLER 无法自动转换") {
 			t.Errorf("SQLEXCEPTION handler 应以注释保留，实际：%s", out)
+		}
+	})
+
+	// P2-16 回归：多行 BEGIN 块 handler 必须整体被注释，
+	// 块内剩余语句不得泄漏进函数体（旧非贪婪匹配只吞到第一个分号）
+	t.Run("多行 BEGIN 块 handler 不泄漏", func(t *testing.T) {
+		out, err := ConvertFunctionDDL(mysql.FunctionInfo{
+			Name: "f_block",
+			DDL: "CREATE FUNCTION f_block() RETURNS INT DETERMINISTIC BEGIN " +
+				"DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN ROLLBACK; RETURN -1; END; " +
+				"RETURN 1; END",
+		})
+		if err != nil {
+			t.Fatalf("ConvertFunctionDDL 返回错误：%v", err)
+		}
+		if !strings.Contains(out, "/* [mysql2pg] MySQL HANDLER 无法自动转换") {
+			t.Errorf("多行 handler 应以块注释保留，实际：%s", out)
+		}
+		// 块注释必须以 */ 闭合，且块尾的孤立 END 不得泄漏
+		if !strings.Contains(out, "*/") {
+			t.Errorf("块注释未闭合，实际：%s", out)
+		}
+		if strings.Count(out, "RETURN -1") != 1 || !strings.Contains(out, "/* [mysql2pg]") {
+			t.Errorf("handler 块内容位置异常，实际：%s", out)
+		}
+	})
+
+	// P2-16：SIGNAL SQLSTATE 转 RAISE EXCEPTION
+	t.Run("SIGNAL 转 RAISE EXCEPTION", func(t *testing.T) {
+		out, err := ConvertFunctionDDL(mysql.FunctionInfo{
+			Name: "f_signal",
+			DDL: "CREATE FUNCTION f_signal(v INT) RETURNS INT DETERMINISTIC BEGIN " +
+				"IF v < 0 THEN SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'v 不能为负'; END IF; " +
+				"RETURN v; END",
+		})
+		if err != nil {
+			t.Fatalf("ConvertFunctionDDL 返回错误：%v", err)
+		}
+		if strings.Contains(out, "SIGNAL") {
+			t.Errorf("SIGNAL 应被转换，实际：%s", out)
+		}
+		if !strings.Contains(out, "RAISE EXCEPTION USING ERRCODE = '45000', MESSAGE = 'v 不能为负';") {
+			t.Errorf("缺少 RAISE EXCEPTION 转换结果，实际：%s", out)
+		}
+	})
+
+	// P2-16：无 MESSAGE_TEXT 的 SIGNAL 与 RESIGNAL
+	t.Run("SIGNAL 无 MESSAGE 与 RESIGNAL", func(t *testing.T) {
+		out, err := ConvertFunctionDDL(mysql.FunctionInfo{
+			Name: "f_signal2",
+			DDL: "CREATE FUNCTION f_signal2(v INT) RETURNS INT DETERMINISTIC BEGIN " +
+				"IF v < 0 THEN SIGNAL SQLSTATE '45001'; END IF; " +
+				"RETURN v; END",
+		})
+		if err != nil {
+			t.Fatalf("ConvertFunctionDDL 返回错误：%v", err)
+		}
+		if !strings.Contains(out, "RAISE EXCEPTION USING ERRCODE = '45001';") {
+			t.Errorf("缺少无 MESSAGE 的 RAISE 转换，实际：%s", out)
 		}
 	})
 }

--- a/internal/converter/postgres/sync_data.go
+++ b/internal/converter/postgres/sync_data.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -40,7 +41,92 @@ const (
 	// streamRowLimit 无主键表采用流式读取的行数上限（P1-06）：
 	// go-sql-driver 在客户端缓冲整个结果集，超过该阈值的表回退 OFFSET 分页以控制内存
 	streamRowLimit = 2000000
+	// maxBatchMemoryBytes 单批次行数据的估算内存预算（P2-07 自适应批大小）：
+	// 行宽×行数超过该预算时按比例下调批大小，防止宽表内存尖峰
+	maxBatchMemoryBytes = 64 * 1024 * 1024
 )
+
+// estimateRowWidth 按列类型估算单行字节宽度（P2-07），保守取大值：
+// 变长字符串按声明长度封顶（上限 512），大对象类型统一按 1024 计
+func estimateRowWidth(columnTypes map[string]string) int {
+	width := 0
+	for _, rawType := range columnTypes {
+		t := strings.ToLower(strings.TrimSpace(rawType))
+		switch {
+		case strings.HasPrefix(t, "tinyint"), strings.HasPrefix(t, "smallint"),
+			strings.HasPrefix(t, "mediumint"), strings.HasPrefix(t, "int"),
+			strings.HasPrefix(t, "bigint"), strings.HasPrefix(t, "year"),
+			strings.HasPrefix(t, "bit"), strings.HasPrefix(t, "bool"):
+			width += 8
+		case strings.HasPrefix(t, "decimal"), strings.HasPrefix(t, "numeric"),
+			strings.HasPrefix(t, "double"), strings.HasPrefix(t, "float"), strings.HasPrefix(t, "real"):
+			width += 16
+		// datetime/timestamp 必须先于 date 判断（前缀包含关系）
+		case strings.HasPrefix(t, "datetime"), strings.HasPrefix(t, "timestamp"), strings.HasPrefix(t, "time"):
+			width += 12
+		case strings.HasPrefix(t, "date"):
+			width += 4
+		case strings.HasPrefix(t, "char("), strings.HasPrefix(t, "varchar("),
+			strings.HasPrefix(t, "binary("), strings.HasPrefix(t, "varbinary("),
+			strings.HasPrefix(t, "enum"), strings.HasPrefix(t, "set"):
+			length := extractTypeLength(t)
+			if length <= 0 {
+				length = 64
+			}
+			if length > 512 {
+				length = 512
+			}
+			width += length
+		case strings.HasPrefix(t, "text"), strings.HasPrefix(t, "longtext"),
+			strings.HasPrefix(t, "mediumtext"), strings.HasPrefix(t, "tinytext"),
+			strings.HasPrefix(t, "blob"), strings.HasPrefix(t, "longblob"),
+			strings.HasPrefix(t, "mediumblob"), strings.HasPrefix(t, "tinyblob"),
+			strings.HasPrefix(t, "json"):
+			width += 1024
+		default:
+			width += 64
+		}
+	}
+	return width
+}
+
+// extractTypeLength 提取 type(n) 形式中的长度 n，无法解析返回 0
+func extractTypeLength(t string) int {
+	open := strings.IndexByte(t, '(')
+	close := strings.IndexByte(t, ')')
+	if open == -1 || close <= open {
+		return 0
+	}
+	numStr := t[open+1 : close]
+	if comma := strings.IndexByte(numStr, ','); comma != -1 {
+		numStr = numStr[:comma]
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(numStr))
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// adaptiveBatchSizes 按估算行宽对批大小做内存预算封顶（P2-07）：
+// 行宽×行数 ≤ maxBatchMemoryBytes 时原样返回，否则按比例下调。
+// 返回调整后的（读取批大小, 插入批大小）
+func adaptiveBatchSizes(readBatch int64, insertBatch int, rowWidth int) (int64, int) {
+	if rowWidth <= 0 {
+		return readBatch, insertBatch
+	}
+	maxRows := int64(maxBatchMemoryBytes) / int64(rowWidth)
+	if maxRows < 1 {
+		maxRows = 1
+	}
+	if readBatch > maxRows {
+		readBatch = maxRows
+	}
+	if insertBatch <= 0 || int64(insertBatch) > maxRows {
+		insertBatch = int(maxRows)
+	}
+	return readBatch, insertBatch
+}
 
 // progressUpdate 无锁进度更新类型
 type progressUpdate struct {
@@ -297,6 +383,18 @@ func paginateAndInsert(ctx context.Context, mysqlConn *mysql.Connection, postgre
 	batchInsertSize := config.Conversion.Limits.BatchInsertSize
 	if batchInsertSize <= 0 {
 		batchInsertSize = defaultBatchInsertSize
+	}
+
+	// P2-07：按估算行宽做内存预算封顶，宽表自动下调批大小，
+	// 普通表行宽估算值远低于预算时保持配置值不变
+	rowWidth := estimateRowWidth(columnTypes)
+	adjustedBatchSize, adjustedInsertSize := adaptiveBatchSizes(batchSize, batchInsertSize, rowWidth)
+	if adjustedBatchSize != batchSize {
+		log("表 %s 估算行宽较大（约 %d 字节/行），读取批大小自适应调整 %d -> %d", table.Name, rowWidth, batchSize, adjustedBatchSize)
+		batchSize = adjustedBatchSize
+	}
+	if adjustedInsertSize != batchInsertSize {
+		batchInsertSize = adjustedInsertSize
 	}
 
 	// 尝试使用基于主键的分页

--- a/internal/converter/postgres/sync_data_p2_test.go
+++ b/internal/converter/postgres/sync_data_p2_test.go
@@ -1,0 +1,77 @@
+package postgres
+
+import (
+	"testing"
+)
+
+// TestEstimateRowWidth P2-07：按列类型估算行宽
+func TestEstimateRowWidth(t *testing.T) {
+	tests := []struct {
+		name    string
+		types   map[string]string
+		wantMin int
+		wantMax int
+	}{
+		{"纯整数列", map[string]string{"a": "bigint(20)", "b": "int"}, 16, 16},
+		{"datetime 不误判为 date", map[string]string{"a": "datetime(6)"}, 12, 12},
+		{"date 单独计宽", map[string]string{"a": "date"}, 4, 4},
+		{"varchar 按声明长度", map[string]string{"a": "varchar(100)"}, 100, 100},
+		{"varchar 超长封顶 512", map[string]string{"a": "varchar(4000)"}, 512, 512},
+		{"大对象统一 1024", map[string]string{"a": "longtext", "b": "json"}, 2048, 2048},
+		{"decimal 计 16", map[string]string{"a": "decimal(10,2)"}, 16, 16},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := estimateRowWidth(tt.types)
+			if got < tt.wantMin || got > tt.wantMax {
+				t.Errorf("estimateRowWidth(%v) = %d, want [%d, %d]", tt.types, got, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
+// TestExtractTypeLength 类型长度提取
+func TestExtractTypeLength(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"varchar(255)", 255},
+		{"decimal(10,2)", 10},
+		{"text", 0},
+		{"varchar(abc)", 0},
+	}
+	for _, tt := range tests {
+		if got := extractTypeLength(tt.input); got != tt.want {
+			t.Errorf("extractTypeLength(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+// TestAdaptiveBatchSizes P2-07：内存预算封顶逻辑
+func TestAdaptiveBatchSizes(t *testing.T) {
+	// 窄表（16 字节/行）：50000 行仅 800KB，远低于预算，保持原值
+	readBatch, insertBatch := adaptiveBatchSizes(50000, 50000, 16)
+	if readBatch != 50000 || insertBatch != 50000 {
+		t.Errorf("窄表不应下调批大小：got (%d, %d)", readBatch, insertBatch)
+	}
+
+	// 超宽表（1MB/行）：预算 64MB → 最多 64 行
+	readBatch, insertBatch = adaptiveBatchSizes(50000, 50000, 1024*1024)
+	wantRows := int64(maxBatchMemoryBytes) / (1024 * 1024)
+	if readBatch != wantRows || int64(insertBatch) != wantRows {
+		t.Errorf("超宽表应下调至 %d 行：got (%d, %d)", wantRows, readBatch, insertBatch)
+	}
+
+	// 极端行宽：至少保留 1 行
+	readBatch, insertBatch = adaptiveBatchSizes(50000, 50000, maxBatchMemoryBytes*2)
+	if readBatch != 1 || insertBatch != 1 {
+		t.Errorf("极端行宽应保底 1 行：got (%d, %d)", readBatch, insertBatch)
+	}
+
+	// 行宽为 0（无列类型信息）：原样返回
+	readBatch, insertBatch = adaptiveBatchSizes(50000, 50000, 0)
+	if readBatch != 50000 || insertBatch != 50000 {
+		t.Errorf("零行宽应原样返回：got (%d, %d)", readBatch, insertBatch)
+	}
+}

--- a/internal/converter/postgres/sync_functions.go
+++ b/internal/converter/postgres/sync_functions.go
@@ -88,14 +88,19 @@ var (
 	reVarDecl = regexp.MustCompile(`(?i)\s*(\w+)\s+(INT|VARCHAR|TEXT|DECIMAL|NUMERIC|DATE|TIME|TIMESTAMP|BOOLEAN|FLOAT|DOUBLE|CHAR|REFCURSOR|TINYINT|BIGINT|MEDIUMINT|SMALLINT)\s*(?:UNSIGNED)?\s*(?:\((\d+(?:,\d+)?)\))?\s*(?:DEFAULT\s+([^;]+))?;`)
 
 	// 基础清理相关
-	reBegin           = regexp.MustCompile(`(?i)BEGIN\s*`)
-	reEnd             = regexp.MustCompile(`(?i)\s*END\s*(?:\$\$|;)*\s*$`)
-	reDeclare         = regexp.MustCompile(`(?i)DECLARE\s*`)
-	reLabel           = regexp.MustCompile(`(?i)\w+:\s*`)
-	reHandler         = regexp.MustCompile(`(?i)DECLARE\s+(CONTINUE|EXIT)\s+HANDLER\s+FOR\s+[^;]+?;`)
-	reHandlerSpecific = regexp.MustCompile(`(?i)DECLARE\s+(CONTINUE|EXIT)\s+HANDLER\s+FOR\s+NOT\s+FOUND\s+.*?;`)
-	reCommentVar      = regexp.MustCompile(`(?i)--\s*声明变量`)
-	reCommentCursor   = regexp.MustCompile(`(?i)--\s*声明游标.*`)
+	reBegin         = regexp.MustCompile(`(?i)BEGIN\s*`)
+	reEnd           = regexp.MustCompile(`(?i)\s*END\s*(?:\$\$|;)*\s*$`)
+	reDeclare       = regexp.MustCompile(`(?i)DECLARE\s*`)
+	reLabel         = regexp.MustCompile(`(?i)\w+:\s*`)
+	reHandlerStart  = regexp.MustCompile(`(?i)DECLARE\s+(CONTINUE|EXIT)\s+HANDLER\s+FOR\s+`)
+	reCommentVar    = regexp.MustCompile(`(?i)--\s*声明变量`)
+	reCommentCursor = regexp.MustCompile(`(?i)--\s*声明游标.*`)
+
+	// P2-16：SIGNAL/RESIGNAL 转换。字面量先经 literalMask 遮蔽，
+	// 遮蔽后的字面量形如 __m2pg_lit_N__ 占位符
+	reSignalStmt    = regexp.MustCompile(`(?i)\bSIGNAL\s+SQLSTATE\s+(__m2pg_lit_\d+__)\s*([^;]*);`)
+	reSignalMessage = regexp.MustCompile(`(?i)\bMESSAGE_TEXT\s*=\s*(__m2pg_lit_\d+__|[A-Za-z_]\w*)`)
+	reResignalStmt  = regexp.MustCompile(`(?i)\bRESIGNAL\b[^;]*;`)
 
 	// 简单函数替换
 	reLower = regexp.MustCompile(`(?i)LOWER\s*\(([^)]+?)\)`)
@@ -480,15 +485,187 @@ func (c *FunctionConverter) extractBody() error {
 // 强加给所有同名（或名字含该子串）的函数，产生不可解释的输出。
 // 无法通用转换的语法应在迁移报告中提示人工复核，而非静默定制改写。
 func (c *FunctionConverter) applySpecificPatches() {
-	// P1-14：DECLARE HANDLER 处理：
-	// FOR NOT FOUND 的语义已由 FETCH 转换覆盖（FETCH 转换生成 IF NOT FOUND THEN done := true），删除声明即可；
-	// 其他 HANDLER（SQLEXCEPTION 等）无法转换，以注释保留原文避免 PG 语法错误，并由迁移报告告警
-	c.body = reHandler.ReplaceAllStringFunc(c.body, func(m string) string {
-		if strings.Contains(strings.ToLower(m), "not found") {
-			return ""
+	// P2-16：先转换 SIGNAL/RESIGNAL——handler 块内部的 SIGNAL 在被整体注释前
+	// 同样完成转换，注释中保留的是转换后的形态
+	c.convertSignalStatements()
+	// P1-14/P2-16：移除/注释 DECLARE HANDLER 声明（含多行 BEGIN 块整体识别）
+	c.removeDeclareHandlers()
+}
+
+// convertSignalStatements 将 MySQL SIGNAL/RESIGNAL 抛错语句转换为 PG RAISE（P2-16）：
+//   - SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'msg' → RAISE EXCEPTION USING ERRCODE = '45000', MESSAGE = 'msg'
+//   - SIGNAL SQLSTATE '45000' → RAISE EXCEPTION USING ERRCODE = '45000'
+//   - RESIGNAL → RAISE（重抛语义依赖 EXCEPTION 块，需人工复核）
+//
+// MESSAGE_TEXT 之外的 SET 子句（MYSQL_ERRNO 等）无 PG 等价物，随改写丢弃。
+// 在字面量遮蔽下进行，MESSAGE_TEXT 的字符串值以占位符形式保留到 unmask 后还原
+func (c *FunctionConverter) convertSignalStatements() {
+	mask := newLiteralMask()
+	c.body = mask.mask(c.body)
+
+	c.body = reSignalStmt.ReplaceAllStringFunc(c.body, func(m string) string {
+		parts := reSignalStmt.FindStringSubmatch(m)
+		if parts == nil {
+			return m
 		}
-		return "-- [mysql2pg] MySQL HANDLER 无法自动转换，原文: " + strings.TrimSpace(m)
+		sqlstate := parts[1]
+		var message string
+		if m2 := reSignalMessage.FindStringSubmatch(parts[2]); m2 != nil {
+			message = m2[1]
+		}
+		if message != "" {
+			return fmt.Sprintf("RAISE EXCEPTION USING ERRCODE = %s, MESSAGE = %s;", sqlstate, message)
+		}
+		return fmt.Sprintf("RAISE EXCEPTION USING ERRCODE = %s;", sqlstate)
 	})
+
+	c.body = reResignalStmt.ReplaceAllString(c.body, "RAISE; -- [mysql2pg] RESIGNAL 转为 RAISE，重抛语义需人工复核")
+
+	c.body = mask.unmask(c.body)
+}
+
+// removeDeclareHandlers 处理 DECLARE HANDLER 声明（P1-14 + P2-16）：
+// FOR NOT FOUND 的语义已由 FETCH 转换覆盖（生成 IF NOT FOUND THEN done := true），删除声明即可；
+// 其他 HANDLER（SQLEXCEPTION 等）无法转换，以块注释保留原文，由迁移报告告警。
+//
+// 旧实现用非贪婪 [^;]+?; 匹配，多行 BEGIN 块只吞到第一个分号，
+// 块内剩余语句（SIGNAL/ROLLBACK/孤立 END）会泄漏进函数体造成 plpgsql 语法错误；
+// 现在整块范围由 findHandlerExtent 以 BEGIN/END 计数（字面量感知）确定
+func (c *FunctionConverter) removeDeclareHandlers() {
+	// from 记录已处理位置：替换产生的注释中含 HANDLER 原文，
+	// 搜索必须从替换结果之后继续，否则会重复匹配
+	from := 0
+	for {
+		loc := reHandlerStart.FindStringIndex(c.body[from:])
+		if loc == nil {
+			return
+		}
+		start := from + loc[0]
+		end := from + findHandlerExtent(c.body, from+loc[1])
+		handlerText := strings.TrimSpace(c.body[start:end])
+
+		var repl string
+		if strings.Contains(strings.ToLower(handlerText), "not found") {
+			repl = ""
+		} else {
+			// 块注释保留原文；防御原文中的 */ 提前终止注释
+			safe := strings.ReplaceAll(handlerText, "*/", "* /")
+			repl = "/* [mysql2pg] MySQL HANDLER 无法自动转换，原文: " + safe + " */"
+		}
+		c.body = c.body[:start] + repl + c.body[end:]
+		from = start + len(repl)
+	}
+}
+
+// findHandlerExtent 确定 DECLARE HANDLER 声明的完整范围（从 FOR 关键字之后开始扫描）：
+// 单语句 handler 结束于第一个 ';'；带 BEGIN 块的 handler 结束于配对的 END;
+func findHandlerExtent(body string, from int) int {
+	i := from
+	upper := strings.ToUpper(body)
+	for i < len(body) {
+		ch := body[i]
+		if ch == '\'' || ch == '"' {
+			i = skipStringLiteral(body, i)
+			continue
+		}
+		if ch == ';' {
+			return i + 1
+		}
+		if isWordAt(upper, i, "BEGIN") {
+			if end := findBeginBlockEnd(body, i); end != -1 {
+				return end
+			}
+			// BEGIN 块未闭合：取到文本末尾，避免块内容泄漏
+			return len(body)
+		}
+		i++
+	}
+	return len(body)
+}
+
+// findBeginBlockEnd 从 beginIdx 处的 BEGIN 开始找到配对 END; 的结束位置
+// （返回 END 后分号之后的下标）。字面量感知：END IF/END LOOP/END WHILE/END CASE
+// 是子块结束符，不与 BEGIN 配对。未闭合返回 -1
+func findBeginBlockEnd(body string, beginIdx int) int {
+	depth := 0
+	i := beginIdx
+	upper := strings.ToUpper(body)
+	for i < len(body) {
+		ch := body[i]
+		if ch == '\'' || ch == '"' {
+			i = skipStringLiteral(body, i)
+			continue
+		}
+		if isWordAt(upper, i, "BEGIN") {
+			depth++
+			i += len("BEGIN")
+			continue
+		}
+		if isWordAt(upper, i, "END") {
+			j := i + len("END")
+			k := j
+			for k < len(body) && (body[k] == ' ' || body[k] == '\t' || body[k] == '\n' || body[k] == '\r') {
+				k++
+			}
+			if isWordAt(upper, k, "IF") || isWordAt(upper, k, "LOOP") ||
+				isWordAt(upper, k, "WHILE") || isWordAt(upper, k, "CASE") {
+				// END IF 等子块结束符，不与 BEGIN 配对
+				i = k
+				continue
+			}
+			depth--
+			if depth == 0 {
+				// 跳过 END 与 ';' 之间可能的标签/空白
+				for k < len(body) && body[k] != ';' {
+					k++
+				}
+				if k < len(body) {
+					return k + 1
+				}
+				return len(body)
+			}
+			i = j
+			continue
+		}
+		i++
+	}
+	return -1
+}
+
+// skipStringLiteral 从 start 处的引号开始跳过一个字符串字面量，
+// 返回字面量之后的下标（支持反斜杠与双写引号转义；未闭合时取到文本末尾）
+func skipStringLiteral(body string, start int) int {
+	quote := body[start]
+	i := start + 1
+	for i < len(body) {
+		if body[i] == '\\' {
+			i += 2
+			continue
+		}
+		if body[i] == quote {
+			if i+1 < len(body) && body[i+1] == quote {
+				i += 2
+				continue
+			}
+			return i + 1
+		}
+		i++
+	}
+	return len(body)
+}
+
+// isWordAt 判断已大写文本 upper 在位置 i 处是否为完整单词 word（前后非标识符字符）
+func isWordAt(upper string, i int, word string) bool {
+	if i+len(word) > len(upper) || upper[i:i+len(word)] != word {
+		return false
+	}
+	if i > 0 && isIdentChar(upper[i-1]) {
+		return false
+	}
+	if i+len(word) < len(upper) && isIdentChar(upper[i+len(word)]) {
+		return false
+	}
+	return true
 }
 
 // convertDataTypes 转换基本数据类型
@@ -1118,7 +1295,11 @@ func (c *FunctionConverter) handleVariables() {
 	// 形如 "单词:" 的内容（issue-12）
 	body = reDeclare.ReplaceAllString(body, "")
 	body = replaceRegexOutsideLiterals(body, reLabel, "")
-	body = reHandler.ReplaceAllString(body, "")
+	// 兜底：以块感知方式继续清理残留的 DECLARE HANDLER
+	// （applySpecificPatches 已处理大部分情形，此处防范特殊形态漏网）
+	c.body = body
+	c.removeDeclareHandlers()
+	body = c.body
 
 	// 2. 提取变量声明
 	processedDeclarations := make(map[string]bool)

--- a/internal/converter/postgres/sync_indexes.go
+++ b/internal/converter/postgres/sync_indexes.go
@@ -8,16 +8,41 @@ import (
 	"github.com/yourusername/mysql2pg/internal/mysql"
 )
 
-// ConvertIndexDDL 将MySQL索引DDL转换为PostgreSQL索引DDL
-func ConvertIndexDDL(tableName string, index mysql.IndexInfo, lowercaseColumns bool, columnNamesMap map[string]string) (string, error) {
+// ConvertIndexDDL 将MySQL索引信息转换为PostgreSQL索引DDL。
+// 返回 PG DDL、降级/跳过告警列表与错误；DDL 为空字符串表示该索引被跳过
+// （调用方仅记日志不视为失败）。tableName 参数已移除（P3-07：
+// 从未使用，表名始终取自 index.Table）。
+//
+// 语义处理（P2-18/P2-19/P2-01）：
+//   - FULLTEXT：按普通 B-tree 索引创建（保留索引可用性），全文检索语义未迁移，记入告警
+//   - SPATIAL：跳过创建（空间索引需 PostGIS 的 GIST 索引），记入告警
+//   - 函数索引部件：跳过创建（表达式索引需人工还原表达式），记入告警
+//   - 前缀索引：前缀长度丢弃、按整列建索引，记入告警
+//   - 降序索引：输出列级 DESC
+//   - USING HASH：映射为 PG 的 USING HASH
+func ConvertIndexDDL(index mysql.IndexInfo, lowercaseColumns bool, columnNamesMap map[string]string) (string, []string, error) {
 	// 检查索引名称是否有效
 	if index.Name == "" {
-		return "", fmt.Errorf("索引名称为空，表：%s", index.Table)
+		return "", nil, fmt.Errorf("索引名称为空，表：%s", index.Table)
 	}
 
 	// 检查表名是否有效
 	if index.Table == "" {
-		return "", fmt.Errorf("索引所属表名为空，索引：%s", index.Name)
+		return "", nil, fmt.Errorf("索引所属表名为空，索引：%s", index.Name)
+	}
+
+	var warnings []string
+
+	// P2-01：函数索引部件的表达式未被采集，无法还原为 PG 表达式索引，跳过创建
+	if index.IsFunctional {
+		warnings = append(warnings, "包含函数索引部件，已跳过创建；PostgreSQL 表达式索引需人工还原表达式后创建")
+		return "", warnings, nil
+	}
+
+	// P2-18 相关：SPATIAL 索引在 PG 需 PostGIS 的 GIST 索引，按普通索引创建无意义，跳过
+	if index.IndexType == "SPATIAL" {
+		warnings = append(warnings, "SPATIAL 索引已跳过创建；需安装 PostGIS 并人工创建 GIST 索引")
+		return "", warnings, nil
 	}
 
 	var uniqueClause string
@@ -27,7 +52,8 @@ func ConvertIndexDDL(tableName string, index mysql.IndexInfo, lowercaseColumns b
 
 	// 为列名添加双引号，保持大小写一致
 	var quotedColumns []string
-	for _, column := range index.Columns {
+	var prefixColumns []string
+	for i, column := range index.Columns {
 		// 处理pri_key特殊情况
 		if strings.ToLower(column) == "pri_key" {
 			continue
@@ -35,27 +61,48 @@ func ConvertIndexDDL(tableName string, index mysql.IndexInfo, lowercaseColumns b
 
 		// 检查列名是否有效
 		if column == "" {
-			return "", fmt.Errorf("索引列名为空，索引：%s，表：%s", index.Name, index.Table)
+			return "", warnings, fmt.Errorf("索引列名为空，索引：%s，表：%s", index.Name, index.Table)
 		}
 
+		colName := column
 		// 使用列名映射获取转换后的列名
 		if convertedColumn, ok := columnNamesMap[column]; ok {
-			column = convertedColumn
+			colName = convertedColumn
 			// 移除双引号，因为后面会重新添加
-			column = strings.Trim(column, `"`)
+			colName = strings.Trim(colName, `"`)
 		}
 
 		// 处理列名大小写
 		if lowercaseColumns {
-			column = strings.ToLower(column)
+			colName = strings.ToLower(colName)
 		}
 
-		quotedColumns = append(quotedColumns, fmt.Sprintf(`"%s"`, column))
+		colExpr := fmt.Sprintf(`"%s"`, colName)
+		// P2-19：降序索引部件输出列级 DESC
+		if i < len(index.ColumnDescs) && index.ColumnDescs[i] {
+			colExpr += " DESC"
+		}
+		quotedColumns = append(quotedColumns, colExpr)
+
+		// P2-19：前缀长度无 PG 等价物，记录后按整列建索引
+		if i < len(index.ColumnSubParts) && index.ColumnSubParts[i] > 0 {
+			prefixColumns = append(prefixColumns, fmt.Sprintf("%s(%d)", column, index.ColumnSubParts[i]))
+		}
+	}
+
+	if len(prefixColumns) > 0 {
+		warnings = append(warnings, fmt.Sprintf("前缀索引列 %s 的前缀长度已丢弃，转为整列索引", strings.Join(prefixColumns, ", ")))
+	}
+
+	// P2-18：FULLTEXT 按普通 B-tree 索引创建（用户选择保留索引可用性），
+	// 全文检索语义未迁移，需人工决策 GIN(to_tsvector) 方案
+	if index.IndexType == "FULLTEXT" {
+		warnings = append(warnings, "FULLTEXT 索引已转为普通 B-tree 索引，全文检索语义未迁移；如需全文检索请人工创建 GIN(to_tsvector(...)) 索引")
 	}
 
 	// 如果没有有效的列名，则跳过这个索引的创建，这通常是因为索引只包含pri_key，而PostgreSQL会自动为主键创建索引
 	if len(quotedColumns) == 0 {
-		return "", nil
+		return "", warnings, nil
 	}
 
 	columns := strings.Join(quotedColumns, ", ")
@@ -74,10 +121,15 @@ func ConvertIndexDDL(tableName string, index mysql.IndexInfo, lowercaseColumns b
 		lowercaseIndexName = fmt.Sprintf("%s_%08x", lowercaseIndexName[:54], sum.Sum32())
 	}
 
-	// 为表名和索引名添加双引号，以处理特殊字符和关键字
-	// 使用index.Table而不是传入的tableName参数，确保索引创建在正确的表上
-	pgDDL := fmt.Sprintf("CREATE %sINDEX IF NOT EXISTS \"%s\" ON \"%s\" (%s);",
-		uniqueClause, lowercaseIndexName, index.Table, columns)
+	// P2-19：USING HASH 映射为 PG 的 HASH 索引访问方法
+	var usingClause string
+	if index.IndexType == "HASH" {
+		usingClause = "USING HASH "
+	}
 
-	return pgDDL, nil
+	// 为表名和索引名添加双引号，以处理特殊字符和关键字
+	pgDDL := fmt.Sprintf("CREATE %sINDEX IF NOT EXISTS \"%s\" ON \"%s\" %s(%s);",
+		uniqueClause, lowercaseIndexName, index.Table, usingClause, columns)
+
+	return pgDDL, warnings, nil
 }

--- a/internal/converter/postgres/sync_indexes_test.go
+++ b/internal/converter/postgres/sync_indexes_test.go
@@ -1,0 +1,223 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/yourusername/mysql2pg/internal/mysql"
+)
+
+// TestConvertIndexDDL_Basic 普通 BTREE 索引转换
+func TestConvertIndexDDL_Basic(t *testing.T) {
+	index := mysql.IndexInfo{
+		Name:      "idx_ab",
+		Table:     "t1",
+		Columns:   []string{"a", "b"},
+		IndexType: "BTREE",
+	}
+	ddl, warnings, err := ConvertIndexDDL(index, true, nil)
+	if err != nil {
+		t.Fatalf("ConvertIndexDDL 返回错误：%v", err)
+	}
+	want := `CREATE INDEX IF NOT EXISTS "t1_idx_ab" ON "t1" ("a", "b");`
+	if ddl != want {
+		t.Errorf("DDL = %q, want %q", ddl, want)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("不应有告警：%v", warnings)
+	}
+}
+
+// TestConvertIndexDDL_UniqueWithColumnMapping 唯一索引 + 列名映射 + 大小写
+func TestConvertIndexDDL_UniqueWithColumnMapping(t *testing.T) {
+	index := mysql.IndexInfo{
+		Name:     "uk_name",
+		Table:    "t1",
+		Columns:  []string{"UserName"},
+		IsUnique: true,
+	}
+	columnNamesMap := map[string]string{"UserName": `"UserName"`}
+	ddl, _, err := ConvertIndexDDL(index, false, columnNamesMap)
+	if err != nil {
+		t.Fatalf("ConvertIndexDDL 返回错误：%v", err)
+	}
+	if !strings.Contains(ddl, `CREATE UNIQUE INDEX IF NOT EXISTS`) || !strings.Contains(ddl, `("UserName")`) {
+		t.Errorf("唯一索引 DDL 错误：%s", ddl)
+	}
+
+	// lowercaseColumns=true 时列名小写
+	ddlLower, _, err := ConvertIndexDDL(index, true, nil)
+	if err != nil {
+		t.Fatalf("ConvertIndexDDL 返回错误：%v", err)
+	}
+	if !strings.Contains(ddlLower, `("username")`) {
+		t.Errorf("列名未小写化：%s", ddlLower)
+	}
+}
+
+// TestConvertIndexDDL_DescIndex P2-19：降序索引输出列级 DESC
+func TestConvertIndexDDL_DescIndex(t *testing.T) {
+	index := mysql.IndexInfo{
+		Name:        "idx_desc",
+		Table:       "t1",
+		Columns:     []string{"a", "b"},
+		ColumnDescs: []bool{false, true},
+		IndexType:   "BTREE",
+	}
+	ddl, _, err := ConvertIndexDDL(index, true, nil)
+	if err != nil {
+		t.Fatalf("ConvertIndexDDL 返回错误：%v", err)
+	}
+	if !strings.Contains(ddl, `("a", "b" DESC)`) {
+		t.Errorf("降序列未输出 DESC：%s", ddl)
+	}
+}
+
+// TestConvertIndexDDL_PrefixIndex P2-19：前缀长度丢弃转整列索引并告警
+func TestConvertIndexDDL_PrefixIndex(t *testing.T) {
+	index := mysql.IndexInfo{
+		Name:           "idx_prefix",
+		Table:          "t1",
+		Columns:        []string{"name"},
+		ColumnSubParts: []int64{10},
+		IndexType:      "BTREE",
+	}
+	ddl, warnings, err := ConvertIndexDDL(index, true, nil)
+	if err != nil {
+		t.Fatalf("ConvertIndexDDL 返回错误：%v", err)
+	}
+	if !strings.Contains(ddl, `("name")`) {
+		t.Errorf("前缀索引未转为整列索引：%s", ddl)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "name(10)") && strings.Contains(w, "前缀长度已丢弃") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("缺少前缀索引降级告警：%v", warnings)
+	}
+}
+
+// TestConvertIndexDDL_Fulltext P2-18：FULLTEXT 按普通 B-tree 创建并告警
+func TestConvertIndexDDL_Fulltext(t *testing.T) {
+	index := mysql.IndexInfo{
+		Name:      "ft_content",
+		Table:     "t1",
+		Columns:   []string{"content"},
+		IndexType: "FULLTEXT",
+	}
+	ddl, warnings, err := ConvertIndexDDL(index, true, nil)
+	if err != nil {
+		t.Fatalf("ConvertIndexDDL 返回错误：%v", err)
+	}
+	if ddl == "" || !strings.Contains(ddl, `("content")`) {
+		t.Errorf("FULLTEXT 索引应创建为普通索引：%s", ddl)
+	}
+	if strings.Contains(ddl, "FULLTEXT") {
+		t.Errorf("DDL 不应包含 FULLTEXT 字样：%s", ddl)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "FULLTEXT") && strings.Contains(w, "全文检索语义未迁移") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("缺少 FULLTEXT 降级告警：%v", warnings)
+	}
+}
+
+// TestConvertIndexDDL_SpatialAndFunctional 跳过的索引类型：SPATIAL 与函数索引
+func TestConvertIndexDDL_SpatialAndFunctional(t *testing.T) {
+	spatial := mysql.IndexInfo{
+		Name:      "sp_geom",
+		Table:     "t1",
+		Columns:   []string{"geom"},
+		IndexType: "SPATIAL",
+	}
+	ddl, warnings, err := ConvertIndexDDL(spatial, true, nil)
+	if err != nil {
+		t.Fatalf("SPATIAL 索引转换返回错误：%v", err)
+	}
+	if ddl != "" {
+		t.Errorf("SPATIAL 索引应跳过创建：%s", ddl)
+	}
+	if len(warnings) == 0 || !strings.Contains(warnings[0], "SPATIAL") {
+		t.Errorf("缺少 SPATIAL 跳过告警：%v", warnings)
+	}
+
+	functional := mysql.IndexInfo{
+		Name:         "idx_func",
+		Table:        "t1",
+		Columns:      []string{},
+		IsFunctional: true,
+		IndexType:    "BTREE",
+	}
+	ddl, warnings, err = ConvertIndexDDL(functional, true, nil)
+	if err != nil {
+		t.Fatalf("函数索引转换返回错误：%v", err)
+	}
+	if ddl != "" {
+		t.Errorf("函数索引应跳过创建：%s", ddl)
+	}
+	if len(warnings) == 0 || !strings.Contains(warnings[0], "函数索引") {
+		t.Errorf("缺少函数索引跳过告警：%v", warnings)
+	}
+}
+
+// TestConvertIndexDDL_Hash P2-19：USING HASH 映射
+func TestConvertIndexDDL_Hash(t *testing.T) {
+	index := mysql.IndexInfo{
+		Name:      "idx_hash",
+		Table:     "t1",
+		Columns:   []string{"code"},
+		IndexType: "HASH",
+	}
+	ddl, _, err := ConvertIndexDDL(index, true, nil)
+	if err != nil {
+		t.Fatalf("ConvertIndexDDL 返回错误：%v", err)
+	}
+	if !strings.Contains(ddl, `USING HASH ("code")`) {
+		t.Errorf("HASH 索引未输出 USING HASH：%s", ddl)
+	}
+}
+
+// TestConvertIndexDDL_LongNameHashSuffix P1-17 回归：超长索引名截断+哈希后缀防碰撞
+func TestConvertIndexDDL_LongNameHashSuffix(t *testing.T) {
+	longSuffixA := strings.Repeat("a", 80)
+	longSuffixB := strings.Repeat("b", 80)
+	indexA := mysql.IndexInfo{Name: "idx_" + longSuffixA, Table: "t1", Columns: []string{"a"}, IndexType: "BTREE"}
+	indexB := mysql.IndexInfo{Name: "idx_" + longSuffixB, Table: "t1", Columns: []string{"a"}, IndexType: "BTREE"}
+
+	ddlA, _, err := ConvertIndexDDL(indexA, true, nil)
+	if err != nil {
+		t.Fatalf("ConvertIndexDDL 返回错误：%v", err)
+	}
+	ddlB, _, err := ConvertIndexDDL(indexB, true, nil)
+	if err != nil {
+		t.Fatalf("ConvertIndexDDL 返回错误：%v", err)
+	}
+	if ddlA == ddlB {
+		t.Errorf("仅尾部不同的长索引名截断后不应撞名：%s", ddlA)
+	}
+	if len(ddlA) == 0 || !strings.Contains(ddlA, "IF NOT EXISTS") {
+		t.Errorf("DDL 生成异常：%s", ddlA)
+	}
+}
+
+// TestConvertIndexDDL_PriKeyOnlySkip 仅含 pri_key 的索引跳过且不告警
+func TestConvertIndexDDL_PriKeyOnlySkip(t *testing.T) {
+	index := mysql.IndexInfo{Name: "PRIMARY", Table: "t1", Columns: []string{"pri_key"}}
+	ddl, warnings, err := ConvertIndexDDL(index, true, nil)
+	if err != nil {
+		t.Fatalf("ConvertIndexDDL 返回错误：%v", err)
+	}
+	if ddl != "" {
+		t.Errorf("pri_key 索引应跳过：%s", ddl)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("pri_key 跳过不应产生告警：%v", warnings)
+	}
+}

--- a/internal/converter/postgres/sync_privilege_p0_test.go
+++ b/internal/converter/postgres/sync_privilege_p0_test.go
@@ -51,7 +51,7 @@ func TestUserPrivilegeRoleNameConsistency(t *testing.T) {
 		User:      "svc.app@%",
 		TableName: "t1",
 		TablePriv: "Select",
-	})
+	}, PrivilegeContext{Database: "targetdb", Schema: "public"})
 	if err != nil {
 		t.Fatalf("ConvertTablePrivilegeDDL 返回错误：%v", err)
 	}
@@ -67,6 +67,53 @@ func TestUserPrivilegeRoleNameConsistency(t *testing.T) {
 	}
 	if strings.Contains(joinedPriv, `"svc.app"`) {
 		t.Errorf("GRANT 不应指向原始用户名 svc.app，实际：%s", joinedPriv)
+	}
+	// P2-09：GRANT 必须指向 schema 限定的表
+	if !strings.Contains(joinedPriv, `ON "public"."t1"`) {
+		t.Errorf("GRANT 应指向 schema 限定的表，实际：%s", joinedPriv)
+	}
+}
+
+// TestSplitGrantObject P2-09：GRANT 对象解析（引号/反引号感知）
+func TestSplitGrantObject(t *testing.T) {
+	tests := []struct {
+		name   string
+		object string
+		want   []string
+	}{
+		{"全局", "*.*", []string{"*", "*"}},
+		{"库级", "test_db.*", []string{"test_db", "*"}},
+		{"反引号表", "`test_db`.`t1`", []string{"test_db", "t1"}},
+		{"库名含点号", "`my.db`.`t1`", []string{"my.db", "t1"}},
+		{"转义反引号", "`a``b`.`t1`", []string{"a`b", "t1"}},
+		{"双引号标识符", `"my.db"."t1"`, []string{"my.db", "t1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitGrantObject(tt.object)
+			if err != nil {
+				t.Fatalf("splitGrantObject(%q) 返回错误：%v", tt.object, err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitGrantObject(%q) = %v, want %v", tt.object, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("splitGrantObject(%q)[%d] = %q, want %q", tt.object, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestParseGrantStatement_DottedName P2-09：库名/表名含点号时解析不错位
+func TestParseGrantStatement_DottedName(t *testing.T) {
+	parsed, err := parseGrantStatement("GRANT SELECT ON `my.db`.`t1` TO 'u'@'%';")
+	if err != nil {
+		t.Fatalf("parseGrantStatement 返回错误：%v", err)
+	}
+	if parsed.Level != "table" || parsed.Database != "my.db" || parsed.Table != "t1" {
+		t.Errorf("解析结果错误：level=%s database=%s table=%s", parsed.Level, parsed.Database, parsed.Table)
 	}
 }
 

--- a/internal/converter/postgres/sync_table_privilege.go
+++ b/internal/converter/postgres/sync_table_privilege.go
@@ -8,10 +8,17 @@ import (
 	"github.com/yourusername/mysql2pg/internal/mysql"
 )
 
-// ConvertTablePrivilegeDDL 将MySQL表权限转换为PostgreSQL表权限
-func ConvertTablePrivilegeDDL(tablePriv mysql.TablePrivInfo) ([]string, error) {
+// ConvertTablePrivilegeDDL 将MySQL表权限转换为PostgreSQL表权限。
+// ctx 提供目标 schema（P2-09）：GRANT 指向 schema 限定的表，
+// 与 tableLevelGrantDDLs 的 TABLE "schema"."table" 形式一致，
+// 不再依赖执行时的 search_path
+func ConvertTablePrivilegeDDL(tablePriv mysql.TablePrivInfo, ctx PrivilegeContext) ([]string, error) {
 
 	var pgDDLs []string
+
+	if ctx.Schema == "" {
+		ctx.Schema = "public"
+	}
 
 	// 提取用户名（处理带主机和不带主机的情况）
 	var rawUserName string
@@ -29,7 +36,7 @@ func ConvertTablePrivilegeDDL(tablePriv mysql.TablePrivInfo) ([]string, error) {
 	// 保证 GRANT 指向的角色与已创建角色一致（issue-11）
 	userName := normalizePGRoleName(rawUserName)
 	quotedRole := quotePGIdentifier(userName)
-	quotedTable := quotePGIdentifier(tablePriv.TableName)
+	quotedTable := fmt.Sprintf("%s.%s", quotePGIdentifier(ctx.Schema), quotePGIdentifier(tablePriv.TableName))
 
 	// 转换权限（忽略大小写）
 	tablePrivStr := strings.ToUpper(tablePriv.TablePriv)

--- a/internal/converter/postgres/sync_tableddl.go
+++ b/internal/converter/postgres/sync_tableddl.go
@@ -1314,8 +1314,9 @@ func processColumnDefinition(line string, lowercaseColumns bool) (columnName str
 	return
 }
 
-// cleanTypeDefinition 清理和规范化类型定义
-func cleanTypeDefinition(typeDefinition string) string {
+// cleanTypeDefinition 清理和规范化类型定义。
+// tinyInt1AsBoolean 控制 tinyint(1) 的映射目标（见 ConvertTableDDLOptions）
+func cleanTypeDefinition(typeDefinition string, tinyInt1AsBoolean bool) string {
 	if strings.Contains(strings.ToLower(typeDefinition), "generated always as") {
 		typeDefinition = reCharsetPrefix.ReplaceAllString(typeDefinition, "$1")
 		typeDefinition = convertGeneratedFunctionsToPostgres(typeDefinition)
@@ -1392,7 +1393,13 @@ func cleanTypeDefinition(typeDefinition string) string {
 		}
 
 		if mysqlType == "tinyint(1)" {
-			lowerTypeDef = reTinyInt1.ReplaceAllString(lowerTypeDef, pgType)
+			// 默认（false）：跳过 BOOLEAN 替换，tinyint(1) 由后续 tinyint 条目
+			// 映射为 SMALLINT，保留整数语义，兼容视图/函数中 `col = 1` 等整数
+			// 比较（PG 无 boolean = integer 运算符，会报 42883）；
+			// 仅当显式开启 tinyint1_as_boolean 时替换为 BOOLEAN
+			if tinyInt1AsBoolean {
+				lowerTypeDef = reTinyInt1.ReplaceAllString(lowerTypeDef, pgType)
+			}
 			continue
 		}
 
@@ -1460,8 +1467,24 @@ func cleanTypeDefinition(typeDefinition string) string {
 	return lowerTypeDef
 }
 
+// ConvertTableDDLOptions ConvertTableDDL 的可选行为参数（变参传入，全部可省略）
+type ConvertTableDDLOptions struct {
+	// TinyInt1AsBoolean 为 true 时 tinyint(1) 映射为 BOOLEAN；
+	// 默认 false 映射为 SMALLINT（保留整数语义，兼容视图/函数中
+	// `col = 1`、`COALESCE(col, 0)` 等用法，避免 PG 报 42883）
+	TinyInt1AsBoolean bool
+	// DistributedByColumns MPP 分布键列
+	DistributedByColumns []string
+}
+
 // ConvertTableDDL 转换MySQL表DDL到PostgreSQL
-func ConvertTableDDL(mysqlDDL string, lowercaseColumns bool, distributedByColumns ...string) (*ConvertTableDDLResult, error) {
+func ConvertTableDDL(mysqlDDL string, lowercaseColumns bool, opts ...ConvertTableDDLOptions) (*ConvertTableDDLResult, error) {
+	var opt ConvertTableDDLOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	distributedByColumns := opt.DistributedByColumns
+
 	// P2-04：仅转换字符串字面量之外的反引号标识符，
 	// 字面量内的反引号（如 COMMENT 'a`b'、enum('x`y')）原样保留
 	mysqlDDL = replaceBackticksOutsideLiterals(mysqlDDL)
@@ -1670,7 +1693,7 @@ func ConvertTableDDL(mysqlDDL string, lowercaseColumns bool, distributedByColumn
 			}
 		}
 
-		typeDefinition = cleanTypeDefinition(typeDefinition)
+		typeDefinition = cleanTypeDefinition(typeDefinition, opt.TinyInt1AsBoolean)
 		if shouldFallbackGeneratedToPlainColumn(typeDefinition) {
 			typeDefinition = stripGeneratedClause(typeDefinition)
 		}

--- a/internal/converter/postgres/sync_tableddl.go
+++ b/internal/converter/postgres/sync_tableddl.go
@@ -33,6 +33,10 @@ var (
 	// 模式将永不匹配，P2-03 修复前的旧模式即因此失效）
 	reTinyInt1       = regexp.MustCompile(`(?i)\btinyint\(1\)`)
 	reJsonWithLength = regexp.MustCompile(`(?i)json\(\d+\)`)
+	// P2-01：PostgreSQL 不支持的 MySQL 8.0 列属性——INVISIBLE 不可见列与
+	// SRID 空间参照标识——转换时剥离，并由 ConvertTableDDL 记入降级告警
+	reInvisibleAttr = regexp.MustCompile(`(?i)\s+invisible\b`)
+	reSridAttr      = regexp.MustCompile(`(?i)\s+srid\s+\d+`)
 
 	// 无符号类型提升相关正则：MySQL 无符号整数需提升为能容纳完整无符号范围的 PG 类型
 	// bigint unsigned -> NUMERIC(20,0)，int unsigned -> BIGINT，smallint unsigned -> INTEGER
@@ -48,8 +52,6 @@ var (
 	reVarcharMissingParen  = regexp.MustCompile(`(?i)varchar\(\d+`)
 	reExtraParens          = regexp.MustCompile(`([a-zA-Z]+)\((\s*\d+\s*)\)\s*\)`)
 	reVarchar              = regexp.MustCompile(`(?i)varchar\(\d+\)`)
-	reEnum                 = regexp.MustCompile(`(?i)enum\(([^)]+)\)`)
-	reSet                  = regexp.MustCompile(`(?i)set\(([^)]+)\)`)
 	reVarcharEnum          = regexp.MustCompile(`(?i)varchar\(\d+\)\(([^)]+)\)`)
 	reVarcharZero          = regexp.MustCompile(`(?i)varchar\(0\)`)
 	reDoublePrecision      = regexp.MustCompile(`(?i)double precision\(\d+,\d+\)`)
@@ -1023,6 +1025,113 @@ func convertCheckExpression(expr string, lowercaseColumns bool) string {
 	return reCheckIfnull.ReplaceAllString(expr, "COALESCE(")
 }
 
+// findTypeKeywordOutsideLiterals 在字面量之外查找类型关键字（大小写不敏感），
+// 并要求关键字前一个字符不是标识符字符，避免把 json_set( 误判为 set( 等
+func findTypeKeywordOutsideLiterals(sql, keyword string, from int) int {
+	idx := findKeywordOutsideLiterals(sql, keyword, from)
+	for idx != -1 {
+		if idx == 0 || !isIdentChar(sql[idx-1]) {
+			return idx
+		}
+		idx = findKeywordOutsideLiterals(sql, keyword, idx+len(keyword))
+	}
+	return -1
+}
+
+// decodeMySQLStringLiteral 解码带单引号的 MySQL 字符串字面量，返回原始内容：
+// 处理 ” 双写转义与反斜杠转义（MySQL 对未识别的转义序列会丢弃反斜杠）
+func decodeMySQLStringLiteral(quoted string) string {
+	if len(quoted) < 2 || quoted[0] != '\'' || !strings.HasSuffix(quoted, "'") {
+		return quoted
+	}
+	body := quoted[1 : len(quoted)-1]
+	var b strings.Builder
+	for i := 0; i < len(body); i++ {
+		ch := body[i]
+		if ch == '\\' && i+1 < len(body) {
+			i++
+			switch body[i] {
+			case 'n':
+				b.WriteByte('\n')
+			case 'r':
+				b.WriteByte('\r')
+			case 't':
+				b.WriteByte('\t')
+			case '0':
+				b.WriteByte(0)
+			case 'Z':
+				b.WriteByte(0x1a)
+			default:
+				// \' \" \\ 及未识别转义：保留转义后的字符本身
+				b.WriteByte(body[i])
+			}
+			continue
+		}
+		if ch == '\'' && i+1 < len(body) && body[i+1] == '\'' {
+			b.WriteByte('\'')
+			i++
+			continue
+		}
+		b.WriteByte(ch)
+	}
+	return b.String()
+}
+
+// parseEnumValues 从列定义行中提取 ENUM 值列表（P2-02），返回解码后的原始字符串；
+// 非 ENUM 列返回 nil。引号与括号感知：值内含 ')' 或引号时不再截断。
+func parseEnumValues(columnLine string) []string {
+	idx := findTypeKeywordOutsideLiterals(columnLine, "enum(", 0)
+	if idx == -1 {
+		return nil
+	}
+	openIdx := idx + len("enum(") - 1
+	closeIdx := findMatchingParen(columnLine, openIdx)
+	if closeIdx == -1 {
+		return nil
+	}
+	var values []string
+	for _, seg := range splitSQLSegments(columnLine[openIdx+1 : closeIdx]) {
+		if seg.kind == segString && len(seg.text) >= 2 && seg.text[0] == '\'' {
+			values = append(values, decodeMySQLStringLiteral(seg.text))
+		}
+	}
+	return values
+}
+
+// isSetTypeColumn 判断列定义是否为 SET 类型（P2-02）。
+// SET 的多值组合语义无法用 CHECK IN 表达，仅降级告警
+func isSetTypeColumn(columnLine string) bool {
+	return findTypeKeywordOutsideLiterals(columnLine, "set(", 0) != -1
+}
+
+// replaceEnumSetTypes 将 enum(...)/set(...) 类型连同完整值列表替换为 VARCHAR(255)。
+// 引号与括号感知：值内含 ')' 不再截断残留垃圾文本（P2-02，
+// 替代旧 reEnum/reSet 的 [^)]+ 模式）。必须在 typeMappingOrder 循环之前执行，
+// 否则 enum/set 关键字会先被 basicTypeRegexes 替换、值列表泄漏到输出
+func replaceEnumSetTypes(typeDef string) string {
+	typeDef = replaceTypeKeywordCall(typeDef, "enum(", "VARCHAR(255)")
+	return replaceTypeKeywordCall(typeDef, "set(", "VARCHAR(255)")
+}
+
+// replaceTypeKeywordCall 反复查找 kw( 形式的类型定义并整体替换为 repl，
+// 括号范围经引号感知的 findMatchingParen 确定
+func replaceTypeKeywordCall(typeDef, kw, repl string) string {
+	from := 0
+	for {
+		idx := findTypeKeywordOutsideLiterals(typeDef, kw, from)
+		if idx == -1 {
+			return typeDef
+		}
+		openIdx := idx + len(kw) - 1
+		closeIdx := findMatchingParen(typeDef, openIdx)
+		if closeIdx == -1 {
+			return typeDef
+		}
+		typeDef = typeDef[:idx] + repl + typeDef[closeIdx+1:]
+		from = idx + len(repl)
+	}
+}
+
 // reDefaultExpr MySQL 8.0 表达式默认值 DEFAULT (expr)
 var reDefaultExpr = regexp.MustCompile(`(?i)\bDEFAULT\s*\(`)
 
@@ -1271,6 +1380,10 @@ func cleanTypeDefinition(typeDefinition string) string {
 	// BIT(n<=63) 走标准映射后残留的 (n) 由 reIntegerWithPrecision 清理
 	lowerTypeDef = reBit64.ReplaceAllString(lowerTypeDef, "NUMERIC(20,0)")
 
+	// P2-02：enum/set 类型连同完整值列表整体替换为 VARCHAR(255)，
+	// 必须在类型映射循环之前执行（否则 enum/set 关键字先被替换、值列表泄漏）
+	lowerTypeDef = replaceEnumSetTypes(lowerTypeDef)
+
 	// 应用类型映射
 	for _, mysqlType := range typeMappingOrder {
 		pgType, exists := typeMap[mysqlType]
@@ -1306,8 +1419,6 @@ func cleanTypeDefinition(typeDefinition string) string {
 	})
 
 	lowerTypeDef = reVarchar.ReplaceAllStringFunc(lowerTypeDef, func(m string) string { return strings.ToUpper(m) })
-	lowerTypeDef = reEnum.ReplaceAllString(lowerTypeDef, "VARCHAR(255)")
-	lowerTypeDef = reSet.ReplaceAllString(lowerTypeDef, "VARCHAR(255)")
 	lowerTypeDef = reVarcharEnum.ReplaceAllString(lowerTypeDef, "VARCHAR(255)")
 	lowerTypeDef = reVarcharZero.ReplaceAllString(lowerTypeDef, "VARCHAR(1)")
 	lowerTypeDef = reDoublePrecision.ReplaceAllString(lowerTypeDef, "DOUBLE PRECISION")
@@ -1335,6 +1446,11 @@ func cleanTypeDefinition(typeDefinition string) string {
 		lowerTypeDef = reCharsetPrefix.ReplaceAllString(lowerTypeDef, "$1")
 		lowerTypeDef = reVirtual.ReplaceAllString(lowerTypeDef, " STORED")
 	}
+
+	// P2-01：剥离 MySQL 8.0 的 INVISIBLE/SRID 列属性（PG 无对应语义，
+	// 字面量感知替换避免误伤默认值字面量；告警由 ConvertTableDDL 按原行检测记入）
+	lowerTypeDef = replaceRegexOutsideLiterals(lowerTypeDef, reInvisibleAttr, "")
+	lowerTypeDef = replaceRegexOutsideLiterals(lowerTypeDef, reSridAttr, "")
 
 	if strings.HasSuffix(lowerTypeDef, ",") {
 		lowerTypeDef = strings.TrimSuffix(lowerTypeDef, ",")
@@ -1478,6 +1594,13 @@ func ConvertTableDDL(mysqlDDL string, lowercaseColumns bool, distributedByColumn
 		// DECIMAL 系 UNSIGNED 需在转换后补 CHECK (col >= 0)（PG 无无符号类型）
 		isUnsignedDecimalLike := isUnsignedDecimalLikeColumn(trimmedLine)
 
+		// P2-01：INVISIBLE/SRID 属性在 cleanTypeDefinition 中剥离，此处按原行检测以便记入告警
+		hasInvisibleAttr := findTypeKeywordOutsideLiterals(trimmedLine, "invisible", 0) != -1
+		hasSridAttr := findTypeKeywordOutsideLiterals(trimmedLine, "srid", 0) != -1
+		// P2-02：ENUM 值列表解析与 SET 类型检测（引号感知，需在类型转换前基于原行进行）
+		enumValues := parseEnumValues(trimmedLine)
+		isSetTypeCol := isSetTypeColumn(trimmedLine)
+
 		columnName, typeDefinition, columnComment, isConstraint, isIncompleteType, defaultWarning, err := processColumnDefinition(trimmedLine, lowercaseColumns)
 		if defaultWarning != "" {
 			warnings = append(warnings, fmt.Sprintf("列 %s: %s", columnName, defaultWarning))
@@ -1564,6 +1687,23 @@ func ConvertTableDDL(mysqlDDL string, lowercaseColumns bool, distributedByColumn
 		if isUnsignedDecimalLike {
 			// MySQL DECIMAL 系 UNSIGNED 的非负语义在 PostgreSQL 中以 CHECK 约束表达
 			newColumnDefinition += fmt.Sprintf(` CHECK ("%s" >= 0)`, columnName)
+		}
+		if len(enumValues) > 0 {
+			// P2-02：ENUM 值域约束以 CHECK IN 表达（SET 的多值组合无法用 IN 表达，仅告警）
+			quotedValues := make([]string, 0, len(enumValues))
+			for _, v := range enumValues {
+				quotedValues = append(quotedValues, "'"+escapeSQLString(v)+"'")
+			}
+			newColumnDefinition += fmt.Sprintf(` CHECK ("%s" IN (%s))`, columnName, strings.Join(quotedValues, ", "))
+		}
+		if isSetTypeCol {
+			warnings = append(warnings, fmt.Sprintf("列 %s: SET 类型的多值组合语义无法用 CHECK 约束表达，已转为 VARCHAR(255)，值域约束未迁移", columnName))
+		}
+		if hasInvisibleAttr {
+			warnings = append(warnings, fmt.Sprintf("列 %s: INVISIBLE 属性无法迁移，列已转为普通可见列", columnName))
+		}
+		if hasSridAttr {
+			warnings = append(warnings, fmt.Sprintf("列 %s: SRID 属性无法迁移已剥离，空间数据完整性依赖应用层保证", columnName))
 		}
 		columnDefinitions = append(columnDefinitions, newColumnDefinition)
 	}

--- a/internal/converter/postgres/sync_tableddl.go
+++ b/internal/converter/postgres/sync_tableddl.go
@@ -29,8 +29,9 @@ var (
 	reCurrentTimestampExtract = regexp.MustCompile(`current_timestamp\((\d+)\)`)
 
 	// 类型映射相关正则
-	reTinyInt1       = regexp.MustCompile(`(?i)\btinyint\(1\)\b`)
-	reJsonLength     = regexp.MustCompile(`(?i)\bjson\((\d+)\)\b`)
+	// tinyint(1) 是 MySQL 的布尔惯例；结尾不能带 \b（`)` 后跟非单词字符时无单词边界，
+	// 模式将永不匹配，P2-03 修复前的旧模式即因此失效）
+	reTinyInt1       = regexp.MustCompile(`(?i)\btinyint\(1\)`)
 	reJsonWithLength = regexp.MustCompile(`(?i)json\(\d+\)`)
 
 	// 无符号类型提升相关正则：MySQL 无符号整数需提升为能容纳完整无符号范围的 PG 类型
@@ -144,19 +145,6 @@ var typeMappingOrder = []string{
 	"geometry", "point", "linestring", "polygon", "multipoint", "multilinestring", "multipolygon", "geometrycollection",
 	// 特殊类型
 	"enum", "set",
-}
-
-// 定义需要保留精度的类型模式
-var typePatterns = map[string]*regexp.Regexp{
-	"decimal":   regexp.MustCompile(`(?i)\bdecimal\((\d+)(?:,(\d+))?\)\b`),
-	"numeric":   regexp.MustCompile(`(?i)\bnumeric\((\d+)(?:,(\d+))?\)\b`),
-	"datetime":  regexp.MustCompile(`(?i)\bdatetime\((\d+)\)\b`),
-	"timestamp": regexp.MustCompile(`(?i)\btimestamp\((\d+)\)\b`),
-	"char":      regexp.MustCompile(`(?i)\bchar\((\d+)\)\b`),
-	"varchar":   regexp.MustCompile(`(?i)\bvarchar\((\d+)\)\b`),
-	"double":    regexp.MustCompile(`(?i)\bdouble\((\d+)(?:,(\d+))?\)\b`),
-	"float":     regexp.MustCompile(`(?i)\bfloat\((\d+)(?:,(\d+))?\)\b`),
-	"time":      regexp.MustCompile(`(?i)\btime\((\d+)\)\b`),
 }
 
 // 类型映射表
@@ -940,64 +928,6 @@ func cleanTableLevelSettings(columnsDefinition string) string {
 	return columnsDefinition
 }
 
-// convertDataType 将MySQL数据类型转换为PostgreSQL数据类型
-func convertDataType(mysqlType string) (postgresType string, isAutoIncrement bool, err error) {
-	postgresType = mysqlType
-	isAutoIncrement = false
-
-	if strings.Contains(strings.ToLower(mysqlType), "auto_increment") {
-		isAutoIncrement = true
-		mysqlType = strings.ReplaceAll(strings.ToLower(mysqlType), "auto_increment", "")
-		mysqlType = strings.TrimSpace(mysqlType)
-	}
-
-	if reTinyInt1.MatchString(mysqlType) {
-		postgresType = "BOOLEAN"
-		return postgresType, isAutoIncrement, nil
-	}
-
-	if reJsonLength.MatchString(mysqlType) {
-		postgresType = "JSON"
-		return postgresType, isAutoIncrement, nil
-	}
-
-	mysqlType = reTypeMb3Direct.ReplaceAllString(mysqlType, "$1")
-	mysqlType = reTypeMb3Any.ReplaceAllString(mysqlType, "$1")
-	mysqlType = reTypeMb3Generic.ReplaceAllString(mysqlType, "$1")
-	mysqlType = reMb3Suffix.ReplaceAllString(mysqlType, "")
-
-	mysqlType = reCharsetFull.ReplaceAllString(mysqlType, "$1")
-	mysqlType = reCharsetSimple.ReplaceAllString(mysqlType, "$1")
-	mysqlType = reCollate.ReplaceAllString(mysqlType, "$1")
-	mysqlType = reComplexCharset.ReplaceAllString(mysqlType, "$1")
-	mysqlType = reComplexCharsetSpecific.ReplaceAllString(mysqlType, "$1")
-	mysqlType = reComplexCharsetVarchar.ReplaceAllString(mysqlType, "$1")
-
-	mysqlType = reMb4Suffix.ReplaceAllString(mysqlType, "$1")
-	mysqlType = strings.TrimSpace(mysqlType)
-
-	for _, mysqlTypeKey := range typeMappingOrder {
-		if strings.Contains(strings.ToLower(mysqlType), strings.ToLower(mysqlTypeKey)) {
-			if pattern, exists := typePatterns[strings.ToLower(mysqlTypeKey)]; exists && pattern.MatchString(mysqlType) {
-				postgresType = mysqlType
-			} else {
-				postgresType = typeMap[mysqlTypeKey]
-			}
-			break
-		}
-	}
-
-	if isAutoIncrement {
-		if postgresType == "BIGINT" {
-			postgresType = "BIGSERIAL"
-		} else {
-			postgresType = "SERIAL"
-		}
-	}
-
-	return postgresType, isAutoIncrement, nil
-}
-
 // promoteUnsignedTypes 将 MySQL 无符号整数类型提升为能容纳完整无符号范围的等价类型，
 // 替换结果仍走标准类型映射链（bigint -> BIGINT、numeric(20,0) -> NUMERIC(20,0) 等）
 // bigint unsigned（0~18446744073709551615）超出 BIGINT 上限，提升为 numeric(20,0)
@@ -1353,51 +1283,10 @@ func cleanTypeDefinition(typeDefinition string) string {
 			continue
 		}
 
-		if pattern, ok := typePatterns[mysqlType]; ok {
-			lowerTypeDef = pattern.ReplaceAllStringFunc(lowerTypeDef, func(m string) string {
-				match := pattern.FindStringSubmatch(m)
-				if len(match) >= 2 {
-					switch mysqlType {
-					case "decimal", "numeric":
-						if len(match) == 3 && match[2] != "" {
-							return fmt.Sprintf("%s(%s,%s)", strings.ToUpper(mysqlType), match[1], match[2])
-						}
-						return fmt.Sprintf("%s(%s)", strings.ToUpper(mysqlType), match[1])
-					case "datetime":
-						return fmt.Sprintf("TIMESTAMP(%s)", match[1])
-					case "timestamp":
-						return fmt.Sprintf("TIMESTAMPTZ(%s)", match[1])
-					case "time":
-						return fmt.Sprintf("TIME(%s)", match[1])
-					case "char":
-						return fmt.Sprintf("CHAR(%s)", match[1])
-					case "varchar":
-						return fmt.Sprintf("VARCHAR(%s)", match[1])
-					case "double":
-						if len(match) == 3 && match[2] != "" {
-							return fmt.Sprintf("DOUBLE PRECISION(%s,%s)", match[1], match[2])
-						}
-						return fmt.Sprintf("DOUBLE PRECISION(%s)", match[1])
-					case "float":
-						if len(match) == 3 && match[2] != "" {
-							return fmt.Sprintf("REAL(%s,%s)", match[1], match[2])
-						}
-						return fmt.Sprintf("REAL(%s)", match[1])
-					default:
-						return pgType
-					}
-				}
-				return pgType
-			})
-		}
-
-		// 使用预编译的正则进行替换
+		// 基本类型关键字替换只替换类型名本身，括号内的精度参数原样保留，
+		// 由 typeMappingOrder 后的兜底正则清理残留（如 double(10,2) 的 (10,2)）
 		if re, ok := basicTypeRegexes[mysqlType]; ok {
 			lowerTypeDef = re.ReplaceAllString(lowerTypeDef, pgType)
-		}
-
-		if mysqlType == "json" {
-			lowerTypeDef = reJsonLength.ReplaceAllString(lowerTypeDef, "JSON")
 		}
 	}
 
@@ -1457,7 +1346,9 @@ func cleanTypeDefinition(typeDefinition string) string {
 
 // ConvertTableDDL 转换MySQL表DDL到PostgreSQL
 func ConvertTableDDL(mysqlDDL string, lowercaseColumns bool, distributedByColumns ...string) (*ConvertTableDDLResult, error) {
-	mysqlDDL = strings.ReplaceAll(mysqlDDL, "`", "\"")
+	// P2-04：仅转换字符串字面量之外的反引号标识符，
+	// 字面量内的反引号（如 COMMENT 'a`b'、enum('x`y')）原样保留
+	mysqlDDL = replaceBackticksOutsideLiterals(mysqlDDL)
 
 	columnNamesMap := make(map[string]string)
 	columnCommentsMap := make(map[string]string)

--- a/internal/converter/postgres/sync_tableddl_p2_test.go
+++ b/internal/converter/postgres/sync_tableddl_p2_test.go
@@ -5,35 +5,50 @@ import (
 	"testing"
 )
 
-// TestCleanTypeDefinition_TinyInt1Boolean P2-03：tinyint(1) → BOOLEAN 映射恢复。
-// 旧正则 \btinyint\(1\)\b 因结尾 \b 在 `)` 后永不匹配，
-// tinyint(1) 静默落入 tinyint → SMALLINT 分支
-func TestCleanTypeDefinition_TinyInt1Boolean(t *testing.T) {
+// TestCleanTypeDefinition_TinyInt1Mapping tinyint(1) 映射策略（P2-03 + 42883 修复）：
+// 默认映射为 SMALLINT 保留整数语义（兼容视图/函数中 `col = 1` 等用法），
+// 显式开启 tinyInt1AsBoolean 时映射为 BOOLEAN。
+// 旧正则 \btinyint\(1\)\b 曾因结尾 \b 永不匹配导致映射静默失效
+func TestCleanTypeDefinition_TinyInt1Mapping(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       string
-		wantContain string
-		notContain  []string
+		name              string
+		input             string
+		wantAsBoolean     string // tinyInt1AsBoolean=true 时应包含
+		wantDefault       string // 默认（false）时应包含
+		notContainDefault []string
 	}{
-		{"tinyint(1) 转 BOOLEAN", "tinyint(1)", "BOOLEAN", []string{"SMALLINT"}},
-		{"大写 TINYINT(1) 转 BOOLEAN", "TINYINT(1) NOT NULL DEFAULT 1", "BOOLEAN", []string{"SMALLINT"}},
-		{"tinyint(1) unsigned 转 BOOLEAN", "tinyint(1) unsigned", "BOOLEAN", []string{"SMALLINT"}},
-		{"tinyint(4) 仍为 SMALLINT", "tinyint(4)", "SMALLINT", []string{"BOOLEAN"}},
-		{"tinyint(10) 仍为 SMALLINT", "tinyint(10)", "SMALLINT", []string{"BOOLEAN"}},
-		{"tinyint 无显示宽度仍为 SMALLINT", "tinyint", "SMALLINT", []string{"BOOLEAN"}},
+		{"tinyint(1)", "tinyint(1)", "BOOLEAN", "SMALLINT", []string{"BOOLEAN"}},
+		{"大写 TINYINT(1) 带修饰", "TINYINT(1) NOT NULL DEFAULT 1", "BOOLEAN", "SMALLINT", []string{"BOOLEAN"}},
+		{"tinyint(1) unsigned", "tinyint(1) unsigned", "BOOLEAN", "SMALLINT", []string{"BOOLEAN"}},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := cleanTypeDefinition(tt.input)
-			if !strings.Contains(got, tt.wantContain) {
-				t.Errorf("cleanTypeDefinition(%q) = %q，不含 %s", tt.input, got, tt.wantContain)
+		t.Run(tt.name+"（默认 SMALLINT）", func(t *testing.T) {
+			got := cleanTypeDefinition(tt.input, false)
+			if !strings.Contains(got, tt.wantDefault) {
+				t.Errorf("cleanTypeDefinition(%q, false) = %q，不含 %s", tt.input, got, tt.wantDefault)
 			}
-			for _, nc := range tt.notContain {
+			for _, nc := range tt.notContainDefault {
 				if strings.Contains(got, nc) {
-					t.Errorf("cleanTypeDefinition(%q) = %q，不应包含 %s", tt.input, got, nc)
+					t.Errorf("cleanTypeDefinition(%q, false) = %q，不应包含 %s", tt.input, got, nc)
 				}
 			}
 		})
+		t.Run(tt.name+"（开启 BOOLEAN）", func(t *testing.T) {
+			got := cleanTypeDefinition(tt.input, true)
+			if !strings.Contains(got, tt.wantAsBoolean) {
+				t.Errorf("cleanTypeDefinition(%q, true) = %q，不含 %s", tt.input, got, tt.wantAsBoolean)
+			}
+		})
+	}
+
+	// 其他 tinyint 变宽不受开关影响
+	for _, input := range []string{"tinyint(4)", "tinyint(10)", "tinyint"} {
+		for _, asBoolean := range []bool{false, true} {
+			got := cleanTypeDefinition(input, asBoolean)
+			if !strings.Contains(got, "SMALLINT") || strings.Contains(got, "BOOLEAN") {
+				t.Errorf("cleanTypeDefinition(%q, %v) = %q，应为 SMALLINT", input, asBoolean, got)
+			}
+		}
 	}
 }
 
@@ -58,11 +73,42 @@ func TestCleanTypeDefinition_PrecisionPreserved(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := cleanTypeDefinition(tt.input)
+			got := cleanTypeDefinition(tt.input, false)
 			if !strings.Contains(got, tt.want) {
 				t.Errorf("cleanTypeDefinition(%q) = %q，不含 %s", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestConvertTableDDL_TinyInt1Option tinyint(1) 映射开关的端到端行为：
+// 默认 SMALLINT（兼容视图/函数中 `col = 1` 的整数比较），开启后 BOOLEAN
+func TestConvertTableDDL_TinyInt1Option(t *testing.T) {
+	mysqlDDL := "CREATE TABLE `t_bool` (\n" +
+		"  `id` bigint NOT NULL,\n" +
+		"  `is_active` tinyint(1) DEFAULT 1,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB"
+
+	// 默认：SMALLINT，视图/函数中的 is_active = 1 保持整数比较语义
+	result, err := ConvertTableDDL(mysqlDDL, true)
+	if err != nil {
+		t.Fatalf("ConvertTableDDL 返回错误：%v", err)
+	}
+	if !strings.Contains(result.DDL, `"is_active" SMALLINT`) {
+		t.Errorf("默认应将 tinyint(1) 转为 SMALLINT：%s", result.DDL)
+	}
+	if strings.Contains(result.DDL, "BOOLEAN") {
+		t.Errorf("默认不应出现 BOOLEAN：%s", result.DDL)
+	}
+
+	// 显式开启：BOOLEAN
+	result, err = ConvertTableDDL(mysqlDDL, true, ConvertTableDDLOptions{TinyInt1AsBoolean: true})
+	if err != nil {
+		t.Fatalf("ConvertTableDDL 返回错误：%v", err)
+	}
+	if !strings.Contains(result.DDL, `"is_active" BOOLEAN`) {
+		t.Errorf("开启选项后应转为 BOOLEAN：%s", result.DDL)
 	}
 }
 

--- a/internal/converter/postgres/sync_tableddl_p2_test.go
+++ b/internal/converter/postgres/sync_tableddl_p2_test.go
@@ -99,3 +99,145 @@ func TestConvertTableDDL_BacktickInLiteral(t *testing.T) {
 		t.Errorf("默认值字面量内的反引号被破坏：%s", result.DDL)
 	}
 }
+
+// TestParseEnumValues P2-02：ENUM 值列表解析（引号/括号感知）
+func TestParseEnumValues(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{"普通值列表", "`status` enum('active','inactive') NOT NULL", []string{"active", "inactive"}},
+		{"值含右括号", "`note` enum('a)b','c')", []string{"a)b", "c"}},
+		{"值含双写单引号", "`note` enum('it''s')", []string{"it's"}},
+		{"值含反斜杠转义单引号", "`note` enum('a\\'b')", []string{"a'b"}},
+		{"非 enum 列", "`c` int NOT NULL", nil},
+		{"字面量内的 enum( 不误判", "`c` varchar(20) DEFAULT 'enum('", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseEnumValues(tt.line)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseEnumValues(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseEnumValues(%q)[%d] = %q, want %q", tt.line, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestIsSetTypeColumn P2-02：SET 类型检测，生成列中的 json_set 不得误判
+func TestIsSetTypeColumn(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"SET 列", "`tags` set('a','b') NULL", true},
+		{"普通列", "`c` int", false},
+		{"生成列 json_set 不误判", "`c1` json GENERATED ALWAYS AS (json_set(`doc`, '$.a', 1)) STORED", false},
+		{"字面量内的 set( 不误判", "`c` varchar(20) DEFAULT 'set('", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSetTypeColumn(tt.line); got != tt.want {
+				t.Errorf("isSetTypeColumn(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestConvertTableDDL_EnumCheckConstraint P2-02：ENUM 转 VARCHAR(255) 并生成 CHECK IN 约束
+func TestConvertTableDDL_EnumCheckConstraint(t *testing.T) {
+	mysqlDDL := "CREATE TABLE `t_enum` (\n" +
+		"  `id` bigint NOT NULL,\n" +
+		"  `status` enum('active','inactive') NOT NULL DEFAULT 'active',\n" +
+		"  `note` enum('a)b','it''s') NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB"
+
+	result, err := ConvertTableDDL(mysqlDDL, true)
+	if err != nil {
+		t.Fatalf("ConvertTableDDL 返回错误：%v", err)
+	}
+
+	if !strings.Contains(result.DDL, `"status" VARCHAR(255) not null default 'active' CHECK ("status" IN ('active', 'inactive'))`) {
+		t.Errorf("status 列缺少 CHECK IN 约束：%s", result.DDL)
+	}
+	// 值含右括号与单引号：完整保留且按 PG 规则转义
+	if !strings.Contains(result.DDL, `CHECK ("note" IN ('a)b', 'it''s'))`) {
+		t.Errorf("note 列 CHECK 约束值列表错误：%s", result.DDL)
+	}
+}
+
+// TestConvertTableDDL_SetColumnWarning P2-02：SET 列转 VARCHAR(255) 且记入降级告警
+func TestConvertTableDDL_SetColumnWarning(t *testing.T) {
+	mysqlDDL := "CREATE TABLE `t_set` (\n" +
+		"  `id` bigint NOT NULL,\n" +
+		"  `tags` set('a','b','c') NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB"
+
+	result, err := ConvertTableDDL(mysqlDDL, true)
+	if err != nil {
+		t.Fatalf("ConvertTableDDL 返回错误：%v", err)
+	}
+
+	if !strings.Contains(result.DDL, `"tags" VARCHAR(255)`) {
+		t.Errorf("tags 列未转为 VARCHAR(255)：%s", result.DDL)
+	}
+	if strings.Contains(result.DDL, "IN (") {
+		t.Errorf("SET 列不应生成 CHECK IN 约束：%s", result.DDL)
+	}
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "SET 类型的多值组合语义") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("缺少 SET 降级告警：%v", result.Warnings)
+	}
+}
+
+// TestConvertTableDDL_InvisibleAndSrid P2-01：INVISIBLE/SRID 属性剥离并记入降级告警
+func TestConvertTableDDL_InvisibleAndSrid(t *testing.T) {
+	mysqlDDL := "CREATE TABLE `t_attrs` (\n" +
+		"  `id` bigint NOT NULL,\n" +
+		"  `c1` int INVISIBLE,\n" +
+		"  `geom` point NOT NULL SRID 4326,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB"
+
+	result, err := ConvertTableDDL(mysqlDDL, true)
+	if err != nil {
+		t.Fatalf("ConvertTableDDL 返回错误：%v", err)
+	}
+
+	if strings.Contains(result.DDL, "INVISIBLE") || strings.Contains(result.DDL, "invisible") {
+		t.Errorf("INVISIBLE 未被剥离：%s", result.DDL)
+	}
+	if strings.Contains(result.DDL, "SRID") || strings.Contains(result.DDL, "srid") {
+		t.Errorf("SRID 未被剥离：%s", result.DDL)
+	}
+
+	var hasInvisibleWarning, hasSridWarning bool
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "INVISIBLE 属性无法迁移") {
+			hasInvisibleWarning = true
+		}
+		if strings.Contains(w, "SRID 属性无法迁移") {
+			hasSridWarning = true
+		}
+	}
+	if !hasInvisibleWarning {
+		t.Errorf("缺少 INVISIBLE 降级告警：%v", result.Warnings)
+	}
+	if !hasSridWarning {
+		t.Errorf("缺少 SRID 降级告警：%v", result.Warnings)
+	}
+}

--- a/internal/converter/postgres/sync_tableddl_p2_test.go
+++ b/internal/converter/postgres/sync_tableddl_p2_test.go
@@ -1,0 +1,101 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCleanTypeDefinition_TinyInt1Boolean P2-03：tinyint(1) → BOOLEAN 映射恢复。
+// 旧正则 \btinyint\(1\)\b 因结尾 \b 在 `)` 后永不匹配，
+// tinyint(1) 静默落入 tinyint → SMALLINT 分支
+func TestCleanTypeDefinition_TinyInt1Boolean(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantContain string
+		notContain  []string
+	}{
+		{"tinyint(1) 转 BOOLEAN", "tinyint(1)", "BOOLEAN", []string{"SMALLINT"}},
+		{"大写 TINYINT(1) 转 BOOLEAN", "TINYINT(1) NOT NULL DEFAULT 1", "BOOLEAN", []string{"SMALLINT"}},
+		{"tinyint(1) unsigned 转 BOOLEAN", "tinyint(1) unsigned", "BOOLEAN", []string{"SMALLINT"}},
+		{"tinyint(4) 仍为 SMALLINT", "tinyint(4)", "SMALLINT", []string{"BOOLEAN"}},
+		{"tinyint(10) 仍为 SMALLINT", "tinyint(10)", "SMALLINT", []string{"BOOLEAN"}},
+		{"tinyint 无显示宽度仍为 SMALLINT", "tinyint", "SMALLINT", []string{"BOOLEAN"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanTypeDefinition(tt.input)
+			if !strings.Contains(got, tt.wantContain) {
+				t.Errorf("cleanTypeDefinition(%q) = %q，不含 %s", tt.input, got, tt.wantContain)
+			}
+			for _, nc := range tt.notContain {
+				if strings.Contains(got, nc) {
+					t.Errorf("cleanTypeDefinition(%q) = %q，不应包含 %s", tt.input, got, nc)
+				}
+			}
+		})
+	}
+}
+
+// TestCleanTypeDefinition_PrecisionPreserved P2-03：删除 typePatterns/convertDataType
+// 死代码后的精度保留回归——实际生效路径是 basicTypeRegexes 关键字替换 + 兜底清理
+func TestCleanTypeDefinition_PrecisionPreserved(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"decimal(10,2)", "DECIMAL(10,2)"},
+		{"decimal(10)", "DECIMAL(10)"},
+		{"numeric(12,4)", "NUMERIC(12,4)"},
+		{"datetime(6)", "TIMESTAMP(6)"},
+		{"timestamp(3)", "TIMESTAMPTZ(3)"},
+		{"varchar(255)", "VARCHAR(255)"},
+		{"char(36)", "CHAR(36)"},
+		{"time(3)", "TIME(3)"},
+		{"float(10,2)", "REAL"},
+		{"double(10,2)", "DOUBLE PRECISION"},
+		{"json", "JSON"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := cleanTypeDefinition(tt.input)
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("cleanTypeDefinition(%q) = %q，不含 %s", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestConvertTableDDL_BacktickInLiteral P2-04：字面量内的反引号不得被替换为双引号，
+// 字面量外的反引号标识符正常转换为双引号
+func TestConvertTableDDL_BacktickInLiteral(t *testing.T) {
+	mysqlDDL := "CREATE TABLE `t1` (\n" +
+		"  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
+		"  `note` varchar(100) DEFAULT 'a`b' COMMENT 'use `backtick` here',\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB"
+
+	result, err := ConvertTableDDL(mysqlDDL, true)
+	if err != nil {
+		t.Fatalf("ConvertTableDDL 返回错误：%v", err)
+	}
+
+	// 标识符反引号应转换为双引号
+	if !strings.Contains(result.DDL, `"note"`) {
+		t.Errorf("DDL 未包含转换后的标识符 \"note\"：%s", result.DDL)
+	}
+
+	// 注释字面量内的反引号原样保留
+	comment, ok := result.ColumnComments["note"]
+	if !ok {
+		t.Fatalf("ColumnComments 缺少 note 的注释：%v", result.ColumnComments)
+	}
+	if !strings.Contains(comment, "`backtick`") {
+		t.Errorf("注释字面量内的反引号被破坏：%q", comment)
+	}
+
+	// 默认值字面量内的反引号原样保留
+	if !strings.Contains(result.DDL, "'a`b'") {
+		t.Errorf("默认值字面量内的反引号被破坏：%s", result.DDL)
+	}
+}

--- a/internal/converter/postgres/sync_tableddl_test.go
+++ b/internal/converter/postgres/sync_tableddl_test.go
@@ -408,7 +408,7 @@ func TestCleanTypeDefinition_EnumWithCharset(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := cleanTypeDefinition(tt.input)
+			result := cleanTypeDefinition(tt.input, false)
 			if result != tt.expected {
 				t.Errorf("cleanTypeDefinition(%q) = %q, want %q", tt.input, result, tt.expected)
 			}

--- a/internal/converter/postgres/sync_user_privilege.go
+++ b/internal/converter/postgres/sync_user_privilege.go
@@ -62,11 +62,12 @@ func parseGrantStatement(grant string) (*parsedGrant, error) {
 	}
 
 	object := strings.TrimSpace(m[2])
-	object = strings.ReplaceAll(object, "`", "")
-	object = strings.ReplaceAll(object, "\"", "")
-	parts := strings.Split(object, ".")
+	parts, err := splitGrantObject(object)
+	if err != nil {
+		return nil, err
+	}
 	switch {
-	case object == "*.*" || object == "*":
+	case len(parts) == 2 && parts[0] == "*" && parts[1] == "*":
 		pg.Level = "global"
 	case len(parts) == 2 && parts[1] == "*":
 		pg.Level = "database"
@@ -75,6 +76,8 @@ func parseGrantStatement(grant string) (*parsedGrant, error) {
 		pg.Level = "table"
 		pg.Database = parts[0]
 		pg.Table = parts[1]
+	case len(parts) == 1 && parts[0] == "*":
+		pg.Level = "global"
 	case len(parts) == 1 && parts[0] != "":
 		pg.Level = "table"
 		pg.Table = parts[0]
@@ -82,6 +85,47 @@ func parseGrantStatement(grant string) (*parsedGrant, error) {
 		pg.Level = "global"
 	}
 	return pg, nil
+}
+
+// splitGrantObject 按点号拆分 GRANT 对象部分，引号/反引号感知（P2-09）：
+// 标识符内的点号（如 `my.db`.`t` 或转义反引号 “ `a“b` “）不作为分隔符。
+// 旧的"剥掉所有引号再 Split"做法在表名/库名含点号或转义反引号时解析错位
+func splitGrantObject(object string) ([]string, error) {
+	var parts []string
+	var cur strings.Builder
+	i := 0
+	for i < len(object) {
+		ch := object[i]
+		switch ch {
+		case '`', '"':
+			quote := ch
+			i++
+			for i < len(object) {
+				if object[i] == quote {
+					if i+1 < len(object) && object[i+1] == quote {
+						cur.WriteByte(quote) // 双写转义
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				cur.WriteByte(object[i])
+				i++
+			}
+		case '.':
+			parts = append(parts, cur.String())
+			cur.Reset()
+			i++
+		case ' ', '\t':
+			i++
+		default:
+			cur.WriteByte(ch)
+			i++
+		}
+	}
+	parts = append(parts, cur.String())
+	return parts, nil
 }
 
 // databaseLevelGrantDDLs 生成 MySQL 全局级/库级权限对应的 PG DDL（P1-09）

--- a/internal/converter/postgres/sync_viewddl.go
+++ b/internal/converter/postgres/sync_viewddl.go
@@ -862,6 +862,10 @@ func ConvertViewDDL(viewName string, viewDefinition string) (string, error) {
 }
 
 // lowerSQLPreservingSingleQuotedLiterals 将 SQL 在单引号字面量外转为小写。
+//
+// 约定（P2-13）：视图管道产出的 DDL 中，单引号字面量以外的所有文本
+// （含 SQL 关键字、双引号标识符、视图名）统一转为小写，与 lowercase_columns
+// 配置无关。依赖混合大小写标识符的视图需人工复核。
 func lowerSQLPreservingSingleQuotedLiterals(sql string) string {
 	if sql == "" {
 		return ""

--- a/internal/mysql/metadata.go
+++ b/internal/mysql/metadata.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,12 @@ type IndexInfo struct {
 	Table    string
 	Columns  []string
 	IsUnique bool
+	// P2-19/P2-01：索引属性细节（来自 information_schema.statistics）。
+	// ColumnSubParts/ColumnDescs 与 Columns 按下标一一对应
+	IndexType      string  // BTREE/HASH/FULLTEXT/SPATIAL（大写，空表示未知）
+	ColumnSubParts []int64 // 各列前缀长度，0 表示无前缀
+	ColumnDescs    []bool  // 各列是否降序（collation = 'D'）
+	IsFunctional   bool    // 含函数索引部件（MySQL 8.0，column_name 为 NULL）
 }
 
 // FunctionInfo 函数信息
@@ -392,14 +399,55 @@ func (c *Connection) getTableColumns(tableName string) ([]ColumnInfo, error) {
 	return columns, nil
 }
 
+// appendIndexRow 将 information_schema.statistics 的一行索引信息追加到 indexMap（P2-19）：
+// 采集前缀长度（sub_part）、排序方向（collation）与索引类型（index_type）；
+// column_name 为 NULL 的行是 MySQL 8.0 函数索引部件，仅做标记（P2-01：
+// 此前直接 Scan 到 string 会报错，导致含函数索引的库在元数据阶段整体中止）
+func appendIndexRow(indexMap map[string]*IndexInfo, key, tableName, indexName string,
+	nonUnique int, columnName, collation, indexType sql.NullString, subPart sql.NullInt64) {
+	info, exists := indexMap[key]
+	if !exists {
+		info = &IndexInfo{
+			Name:     indexName,
+			Table:    tableName,
+			IsUnique: nonUnique == 0,
+		}
+		indexMap[key] = info
+	}
+	if indexType.Valid && info.IndexType == "" {
+		info.IndexType = strings.ToUpper(indexType.String)
+	}
+	if !columnName.Valid {
+		info.IsFunctional = true
+		return
+	}
+	info.Columns = append(info.Columns, columnName.String)
+	var sp int64
+	if subPart.Valid {
+		sp = subPart.Int64
+	}
+	info.ColumnSubParts = append(info.ColumnSubParts, sp)
+	info.ColumnDescs = append(info.ColumnDescs, collation.Valid && strings.ToUpper(collation.String) == "D")
+}
+
+// sortIndexes 按表名、索引名稳定排序（map 遍历顺序不确定，避免索引创建顺序漂移）
+func sortIndexes(indexes []IndexInfo) {
+	sort.Slice(indexes, func(i, j int) bool {
+		if indexes[i].Table != indexes[j].Table {
+			return indexes[i].Table < indexes[j].Table
+		}
+		return indexes[i].Name < indexes[j].Name
+	})
+}
+
 // getTableIndexes 获取表的索引信息
 func (c *Connection) getTableIndexes(tableName string) ([]IndexInfo, error) {
 	// 使用information_schema.statistics查询索引信息，兼容MySQL 5.7和MySQL 8.0
-	// 只查询需要的字段：table_name, index_name, non_unique, column_name, seq_in_index
 	query := `
-		SELECT table_name, index_name, non_unique, column_name, seq_in_index 
-		FROM information_schema.statistics 
-		WHERE table_schema = ? AND table_name = ? 
+		SELECT table_name, index_name, non_unique, column_name, seq_in_index,
+		       sub_part, collation, index_type
+		FROM information_schema.statistics
+		WHERE table_schema = ? AND table_name = ?
 		ORDER BY index_name, seq_in_index
 	`
 	rows, err := c.db.QueryContext(c.context(), query, c.config.Database, tableName)
@@ -412,23 +460,18 @@ func (c *Connection) getTableIndexes(tableName string) ([]IndexInfo, error) {
 	indexMap := make(map[string]*IndexInfo)
 
 	for rows.Next() {
-		var tableName, indexName, columnName string
+		var tableName, indexName string
 		var nonUnique int
-		var seqInIndex sql.NullString
+		var seqInIndex, columnName, collation, indexType sql.NullString
+		var subPart sql.NullInt64
 
-		if err := rows.Scan(&tableName, &indexName, &nonUnique, &columnName, &seqInIndex); err != nil {
+		if err := rows.Scan(&tableName, &indexName, &nonUnique, &columnName, &seqInIndex,
+			&subPart, &collation, &indexType); err != nil {
 			return nil, err
 		}
 
-		if _, exists := indexMap[indexName]; !exists {
-			indexMap[indexName] = &IndexInfo{
-				Name:     indexName,
-				Table:    tableName,
-				IsUnique: nonUnique == 0,
-			}
-		}
-
-		indexMap[indexName].Columns = append(indexMap[indexName].Columns, columnName)
+		appendIndexRow(indexMap, indexName, tableName, indexName,
+			nonUnique, columnName, collation, indexType, subPart)
 	}
 
 	// 将map转换为slice
@@ -436,6 +479,7 @@ func (c *Connection) getTableIndexes(tableName string) ([]IndexInfo, error) {
 	for _, idx := range indexMap {
 		indexes = append(indexes, *idx)
 	}
+	sortIndexes(indexes)
 
 	return indexes, nil
 }
@@ -444,7 +488,8 @@ func (c *Connection) getTableIndexes(tableName string) ([]IndexInfo, error) {
 func (c *Connection) GetAllIndexes() ([]IndexInfo, error) {
 	// 使用 information_schema.statistics 查询所有索引信息
 	query := `
-		SELECT table_name, index_name, non_unique, column_name, seq_in_index
+		SELECT table_name, index_name, non_unique, column_name, seq_in_index,
+		       sub_part, collation, index_type
 		FROM information_schema.statistics
 		WHERE table_schema = ?
 		  AND table_schema NOT IN ('mysql', 'information_schema', 'performance_schema', 'sys')
@@ -460,24 +505,18 @@ func (c *Connection) GetAllIndexes() ([]IndexInfo, error) {
 	indexMap := make(map[string]*IndexInfo)
 
 	for rows.Next() {
-		var tableName, indexName, columnName string
+		var tableName, indexName string
 		var nonUnique int
-		var seqInIndex sql.NullString
+		var seqInIndex, columnName, collation, indexType sql.NullString
+		var subPart sql.NullInt64
 
-		if err := rows.Scan(&tableName, &indexName, &nonUnique, &columnName, &seqInIndex); err != nil {
+		if err := rows.Scan(&tableName, &indexName, &nonUnique, &columnName, &seqInIndex,
+			&subPart, &collation, &indexType); err != nil {
 			return nil, fmt.Errorf("扫描索引信息失败：%w", err)
 		}
 
-		key := tableName + "." + indexName
-		if _, exists := indexMap[key]; !exists {
-			indexMap[key] = &IndexInfo{
-				Name:     indexName,
-				Table:    tableName,
-				IsUnique: nonUnique == 0,
-			}
-		}
-
-		indexMap[key].Columns = append(indexMap[key].Columns, columnName)
+		appendIndexRow(indexMap, tableName+"."+indexName, tableName, indexName,
+			nonUnique, columnName, collation, indexType, subPart)
 	}
 
 	if err := rows.Err(); err != nil {
@@ -489,6 +528,7 @@ func (c *Connection) GetAllIndexes() ([]IndexInfo, error) {
 	for _, idx := range indexMap {
 		indexes = append(indexes, *idx)
 	}
+	sortIndexes(indexes)
 
 	return indexes, nil
 }

--- a/internal/mysql/metadata.go
+++ b/internal/mysql/metadata.go
@@ -758,7 +758,8 @@ func (c *Connection) GetUsers() ([]UserInfo, error) {
 		user != 'mysql.pfs_admin' AND user != 'mysql.pfs_admin_role' AND
 		user != 'mysql.pfs_role_admin' AND user != 'mysql.pfs_role_admin_role' AND
 		user != 'mysql.pfs_role_admin_role_role' AND
-		user != 'mysql.pfs_role_admin_role_role_role' AND user != 'mysql.pfsadmin'
+		user != 'mysql.pfs_role_admin_role_role_role' AND user != 'mysql.pfsadmin' AND
+		user != 'mysql.debian-sys-maint'
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("获取用户列表失败: %w", err)

--- a/internal/mysql/metadata_indexes_test.go
+++ b/internal/mysql/metadata_indexes_test.go
@@ -1,0 +1,72 @@
+package mysql
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// TestAppendIndexRow_FunctionalNullColumn P2-01：函数索引部件的 NULL 列名
+// 只标记 IsFunctional，不得报错或写入空列名
+func TestAppendIndexRow_FunctionalNullColumn(t *testing.T) {
+	indexMap := make(map[string]*IndexInfo)
+
+	appendIndexRow(indexMap, "idx_func", "t1", "idx_func", 1,
+		sql.NullString{Valid: false}, sql.NullString{String: "A", Valid: true},
+		sql.NullString{String: "BTREE", Valid: true}, sql.NullInt64{Valid: false})
+
+	info, ok := indexMap["idx_func"]
+	if !ok {
+		t.Fatal("索引未被记录")
+	}
+	if !info.IsFunctional {
+		t.Error("NULL 列名应标记 IsFunctional")
+	}
+	if len(info.Columns) != 0 {
+		t.Errorf("NULL 列名不应写入 Columns：%v", info.Columns)
+	}
+	if info.IndexType != "BTREE" {
+		t.Errorf("IndexType = %q, want BTREE", info.IndexType)
+	}
+}
+
+// TestAppendIndexRow_PrefixAndDesc P2-19：前缀长度与降序方向采集
+func TestAppendIndexRow_PrefixAndDesc(t *testing.T) {
+	indexMap := make(map[string]*IndexInfo)
+
+	appendIndexRow(indexMap, "idx_mix", "t1", "idx_mix", 1,
+		sql.NullString{String: "name", Valid: true}, sql.NullString{String: "A", Valid: true},
+		sql.NullString{String: "BTREE", Valid: true}, sql.NullInt64{Int64: 10, Valid: true})
+	appendIndexRow(indexMap, "idx_mix", "t1", "idx_mix", 1,
+		sql.NullString{String: "created_at", Valid: true}, sql.NullString{String: "D", Valid: true},
+		sql.NullString{String: "BTREE", Valid: true}, sql.NullInt64{Valid: false})
+
+	info := indexMap["idx_mix"]
+	if info == nil {
+		t.Fatal("索引未被记录")
+	}
+	if len(info.Columns) != 2 || info.Columns[0] != "name" || info.Columns[1] != "created_at" {
+		t.Fatalf("Columns = %v", info.Columns)
+	}
+	if info.ColumnSubParts[0] != 10 || info.ColumnSubParts[1] != 0 {
+		t.Errorf("ColumnSubParts = %v", info.ColumnSubParts)
+	}
+	if info.ColumnDescs[0] || !info.ColumnDescs[1] {
+		t.Errorf("ColumnDescs = %v", info.ColumnDescs)
+	}
+	if info.IsUnique {
+		t.Error("non_unique=1 不应为唯一索引")
+	}
+}
+
+// TestSortIndexes 稳定排序：按表名、索引名
+func TestSortIndexes(t *testing.T) {
+	indexes := []IndexInfo{
+		{Name: "z_idx", Table: "t2"},
+		{Name: "a_idx", Table: "t2"},
+		{Name: "m_idx", Table: "t1"},
+	}
+	sortIndexes(indexes)
+	if indexes[0].Table != "t1" || indexes[1].Name != "a_idx" || indexes[2].Name != "z_idx" {
+		t.Errorf("排序结果错误：%+v", indexes)
+	}
+}

--- a/internal/postgres/connection.go
+++ b/internal/postgres/connection.go
@@ -746,19 +746,29 @@ func (c *Connection) GetTableRowCount(tableName string) (int64, error) {
 // 返回 (false, nil) 表示目标列未关联序列（如既有表非 SERIAL 建表），调用方应告警并继续。
 func (c *Connection) SyncAutoIncrementSequence(tableName, columnName string, nextValueLowerBound int64) (bool, error) {
 	ctx := c.context()
-	tbl := pgQuoteIdentifier(tableName)
-	col := pgQuoteIdentifier(columnName)
-	query := fmt.Sprintf(
-		`SELECT setval(pg_get_serial_sequence('%s', '%s'), GREATEST(COALESCE((SELECT MAX(%s) FROM %s), 0) + 1, %d), false)`,
-		strings.ReplaceAll(tbl, "'", "''"),
-		strings.ReplaceAll(col, "'", "''"),
-		col, tbl, nextValueLowerBound)
+	query := buildSequenceBackfillQuery(tableName, columnName, nextValueLowerBound)
 
 	var next *int64
 	if err := c.pool.QueryRow(ctx, query).Scan(&next); err != nil {
 		return false, fmt.Errorf("回填表 %s 列 %s 序列失败：%w", tableName, columnName, err)
 	}
 	return next != nil, nil
+}
+
+// buildSequenceBackfillQuery 构造序列回填 SQL。
+// 注意 pg_get_serial_sequence(table, column) 两个文本参数的差异：
+// 表名参数 PG 按标识符规则解析（可带双引号），列名参数直接与
+// pg_attribute.attname 精确比较、不解析双引号——必须传裸列名，
+// 否则 PG 查找字面含引号的列名报 42703（column ""id"" does not exist）。
+// MAX()/FROM 位置仍使用双引号标识符以兼容特殊字符与大小写敏感列名。
+func buildSequenceBackfillQuery(tableName, columnName string, nextValueLowerBound int64) string {
+	tbl := pgQuoteIdentifier(tableName)
+	col := pgQuoteIdentifier(columnName)
+	return fmt.Sprintf(
+		`SELECT setval(pg_get_serial_sequence('%s', '%s'), GREATEST(COALESCE((SELECT MAX(%s) FROM %s), 0) + 1, %d), false)`,
+		strings.ReplaceAll(tbl, "'", "''"),
+		strings.ReplaceAll(columnName, "'", "''"),
+		col, tbl, nextValueLowerBound)
 }
 
 // pgQuoteIdentifier 用双引号包裹 PostgreSQL 标识符，并转义其中的双引号

--- a/internal/postgres/connection_test.go
+++ b/internal/postgres/connection_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"database/sql"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -271,5 +272,31 @@ func TestConvertBatchColumnValueBitAndTime(t *testing.T) {
 	// datetime 列不走 TIME 范围检查
 	if got := convertBatchColumnValue("dt", "2024-01-01 10:00:00", columnTypes); got != "2024-01-01 10:00:00" {
 		t.Fatalf("datetime 值期望透传，实际 %v", got)
+	}
+}
+
+// TestBuildSequenceBackfillQuery 序列回填 SQL 构造（issue：column ""id"" does not exist）：
+// pg_get_serial_sequence 的列参数是裸列名（PG 不解析其中双引号），
+// MAX()/FROM 位置则保持双引号标识符
+func TestBuildSequenceBackfillQuery(t *testing.T) {
+	query := buildSequenceBackfillQuery("t1", "id", 100)
+
+	if !strings.Contains(query, `pg_get_serial_sequence('"t1"', 'id')`) {
+		t.Errorf("pg_get_serial_sequence 列参数应为裸列名：%s", query)
+	}
+	if strings.Contains(query, `'''id''`) || strings.Contains(query, `'\"id\"'`) || strings.Contains(query, `'"id"'`) {
+		t.Errorf("pg_get_serial_sequence 列参数不得带双引号：%s", query)
+	}
+	if !strings.Contains(query, `MAX("id") FROM "t1"`) {
+		t.Errorf("MAX/FROM 位置应使用双引号标识符：%s", query)
+	}
+	if !strings.Contains(query, "100") {
+		t.Errorf("缺少序列下限值：%s", query)
+	}
+
+	// 列名含单引号时按字符串字面量规则双写转义
+	query = buildSequenceBackfillQuery("t1", "a'b", 1)
+	if !strings.Contains(query, `'a''b'`) {
+		t.Errorf("列名中的单引号应双写转义：%s", query)
 	}
 }


### PR DESCRIPTION
1、[fix: resolve 3 P2 items from converter analysis](https://github.com/xfg0218/MySQL2PG/commit/d16efb7c909c691be239d36a0de5ade0d076f7d3)
2、fix: preserve ENUM value domain and strip MySQL 8.0 column attrs 
3、[fix: index pipeline overhaul — functional/prefix/DESC/HASH/FULLTEXT/S…](https://github.com/xfg0218/MySQL2PG/commit/f0a8c9e08b626fd1f4a1dea7c72a1b9728099346)
4、[fix: adaptive batch sizing and SIGNAL/HANDLER conversion (P2-07/16)](https://github.com/xfg0218/MySQL2PG/commit/91bd67162ad1ec1bef1bfad8c69099aaaefb9798)
5、[fix: privilege residuals and false FK-disabling claims (P2-09/17)](https://github.com/xfg0218/MySQL2PG/commit/cf182e44d702fff4bc782dd674beccd4d84b2e8f)
6、[fix: sequence backfill failed with column ""id"" does not exist (42703)](https://github.com/xfg0218/MySQL2PG/commit/801fee28b6303ddc5344bdac35a093d6d01484e8)
7、[fix: tinyint(1) defaults to SMALLINT; BOOLEAN now opt-in (42883)](https://github.com/xfg0218/MySQL2PG/commit/9ab1a47783cb334a86b8ac573470ed5a42aba523)
8、[GetUsers remove debian-sys-maint user](https://github.com/xfg0218/MySQL2PG/commit/ac67ccf57ad1e36d87fe5ff5b78cbda998b25f11)