### PR TITLE
修复复合主键sql参数与占位符参数数量不一致的问题（分页同步表 CompositePrimaryKey 失败: 获取表数据失败：sql: …

### DIFF
--- a/internal/postgres/connection.go
+++ b/internal/postgres/connection.go
@@ -990,14 +990,16 @@ func (c *Connection) BatchInsertDataWithCompositeKeys(ctx context.Context, tx pg
 		if primaryKey == "" {
 			continue
 		}
+		found := false
 		for i, col := range columns {
 			if strings.EqualFold(col, primaryKey) {
 				resolvedPrimaryKeys = append(resolvedPrimaryKeys, copyColumns[i])
+				found = true
 				break
 			}
 		}
 		// fallback: 如果没找到，使用转换后的主键名
-		if len(resolvedPrimaryKeys) < len(primaryKeys) {
+		if !found {
 			resolvedPK := primaryKey
 			if lowercaseColumns {
 				resolvedPK = strings.ToLower(primaryKey)


### PR DESCRIPTION
转换失败: 共 2 个错误:
- 同步失败 (3/4 个表失败):
- 分页同步表 sys_user_post 失败: 获取表数据失败：sql: expected 2 arguments, got 3
- 分页同步表 sys_user_role 失败: 获取表数据失败：sql: expected 2 arguments, got 3

CREATE TABLE `sys_user_post` (
  `user_id` bigint NOT NULL COMMENT '用户ID',
  `post_id` bigint NOT NULL COMMENT '岗位ID',
  PRIMARY KEY (`user_id`,`post_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='用户与岗位关联表';

迁移复合主键的mysql表报错，SQL 里只有 2 个占位符、却传入了 3 个参数。
internal/postgres/connection.go:988在解析所有主键列名时，996行的break只会退出993行的for循环，会接着执行下面if len(resolvedPrimaryKeys) < len(primaryKeys) 指令